### PR TITLE
Fix: swap seq

### DIFF
--- a/core/src/instructions/liquidity/mod.rs
+++ b/core/src/instructions/liquidity/mod.rs
@@ -1,4 +1,7 @@
-use core::{iter::Chain, slice};
+use core::{
+    iter::{once, Chain, Once},
+    slice,
+};
 
 use inf1_ctl_core::instructions::liquidity as inf1_ctl_core_liquidity;
 use inf1_svc_core::traits::SolValCalcAccs;
@@ -52,10 +55,7 @@ impl<T, I, C: SolValCalcAccs, P> IxArgs<T, I, C, P> {
 }
 
 pub type AccsIter<'a, T> = Chain<
-    Chain<
-        Chain<Chain<slice::Iter<'a, T>, slice::Iter<'a, T>>, slice::Iter<'a, T>>,
-        slice::Iter<'a, T>,
-    >,
+    Chain<Chain<Chain<slice::Iter<'a, T>, Once<&'a T>>, slice::Iter<'a, T>>, Once<&'a T>>,
     slice::Iter<'a, T>,
 >;
 
@@ -72,9 +72,9 @@ impl<T, I: AsRef<[T]>, C: AsRef<[T]>, P: AsRef<[T]>> IxAccs<T, I, C, P> {
         ix_prefix
             .as_ref()
             .iter()
-            .chain(core::slice::from_ref(lst_calc_prog))
+            .chain(once(lst_calc_prog))
             .chain(lst_calc.as_ref())
-            .chain(core::slice::from_ref(pricing_prog))
+            .chain(once(pricing_prog))
             .chain(pricing.as_ref())
     }
 }

--- a/core/src/instructions/swap/exact_in.rs
+++ b/core/src/instructions/swap/exact_in.rs
@@ -7,57 +7,79 @@ use inf1_svc_core::traits::SolValCalcAccs;
 
 use super::{IxAccs, IxArgs};
 
-pub type SwapExactInIxAccs<I, C, D, P> = IxAccs<I, C, D, P>;
+pub type SwapExactInIxAccs<T, I, C, D, P> = IxAccs<T, I, C, D, P>;
 
-pub type SwapExactInIxArgs<I, C, D, P> = IxArgs<I, C, D, P>;
+pub type SwapExactInIxArgs<T, I, C, D, P> = IxArgs<T, I, C, D, P>;
 
-/// Use return value with [`super::swap_ix_accs_seq`] to create array
 pub fn swap_exact_in_ix_keys_owned<C: SolValCalcAccs, D: SolValCalcAccs, P: PriceExactInAccs>(
     SwapExactInIxAccs {
         ix_prefix,
-        pricing,
+        inp_calc_prog,
         inp_calc,
+        out_calc_prog,
         out_calc,
-    }: &SwapExactInIxAccs<SwapExactInIxPreKeysOwned, C, D, P>,
-) -> SwapExactInIxAccs<SwapExactInIxPreKeysOwned, C::KeysOwned, D::KeysOwned, P::KeysOwned> {
+        pricing_prog,
+        pricing,
+    }: &SwapExactInIxAccs<[u8; 32], SwapExactInIxPreKeysOwned, C, D, P>,
+) -> SwapExactInIxAccs<[u8; 32], SwapExactInIxPreKeysOwned, C::KeysOwned, D::KeysOwned, P::KeysOwned>
+{
     IxAccs {
         ix_prefix: *ix_prefix,
+        inp_calc_prog: *inp_calc_prog,
         inp_calc: inp_calc.suf_keys_owned(),
+        out_calc_prog: *out_calc_prog,
         out_calc: out_calc.suf_keys_owned(),
+        pricing_prog: *pricing_prog,
         pricing: pricing.suf_keys_owned(),
     }
 }
 
-/// Use return value with [`super::swap_ix_accs_seq`] to create array
-pub fn swap_exact_in_ix_is_signer<I, C: SolValCalcAccs, D: SolValCalcAccs, P: PriceExactInAccs>(
+pub fn swap_exact_in_ix_is_signer<
+    T,
+    I,
+    C: SolValCalcAccs,
+    D: SolValCalcAccs,
+    P: PriceExactInAccs,
+>(
     SwapExactInIxAccs {
         pricing,
         inp_calc,
         out_calc,
         ..
-    }: &SwapExactInIxAccs<I, C, D, P>,
-) -> SwapExactInIxAccs<SwapExactInIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
+    }: &SwapExactInIxAccs<bool, I, C, D, P>,
+) -> SwapExactInIxAccs<bool, SwapExactInIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
     IxAccs {
         ix_prefix: SWAP_EXACT_IN_IX_PRE_IS_SIGNER,
+        inp_calc_prog: false,
         inp_calc: inp_calc.suf_is_signer(),
+        out_calc_prog: false,
         out_calc: out_calc.suf_is_signer(),
+        pricing_prog: false,
         pricing: pricing.suf_is_signer(),
     }
 }
 
-/// Use return value with [`super::swap_ix_accs_seq`] to create array
-pub fn swap_exact_in_ix_is_writer<I, C: SolValCalcAccs, D: SolValCalcAccs, P: PriceExactInAccs>(
+pub fn swap_exact_in_ix_is_writer<
+    T,
+    I,
+    C: SolValCalcAccs,
+    D: SolValCalcAccs,
+    P: PriceExactInAccs,
+>(
     SwapExactInIxAccs {
         pricing,
         inp_calc,
         out_calc,
         ..
-    }: &SwapExactInIxAccs<I, C, D, P>,
-) -> SwapExactInIxAccs<SwapExactInIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
+    }: &SwapExactInIxAccs<T, I, C, D, P>,
+) -> SwapExactInIxAccs<bool, SwapExactInIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
     IxAccs {
         ix_prefix: SWAP_EXACT_IN_IX_PRE_IS_WRITER,
+        inp_calc_prog: false,
         inp_calc: inp_calc.suf_is_writer(),
+        out_calc_prog: false,
         out_calc: out_calc.suf_is_writer(),
+        pricing_prog: false,
         pricing: pricing.suf_is_writer(),
     }
 }

--- a/core/src/instructions/swap/exact_out.rs
+++ b/core/src/instructions/swap/exact_out.rs
@@ -7,29 +7,40 @@ use inf1_svc_core::traits::SolValCalcAccs;
 
 use super::{IxAccs, IxArgs};
 
-pub type SwapExactOutIxAccs<I, C, D, P> = IxAccs<I, C, D, P>;
+pub type SwapExactOutIxAccs<T, I, C, D, P> = IxAccs<T, I, C, D, P>;
 
-pub type SwapExactOutIxArgs<I, C, D, P> = IxArgs<I, C, D, P>;
+pub type SwapExactOutIxArgs<T, I, C, D, P> = IxArgs<T, I, C, D, P>;
 
-/// Use return value with [`super::swap_ix_accs_seq`] to create array
 pub fn swap_exact_out_ix_keys_owned<C: SolValCalcAccs, D: SolValCalcAccs, P: PriceExactOutAccs>(
     SwapExactOutIxAccs {
         ix_prefix,
-        pricing,
+        inp_calc_prog,
         inp_calc,
+        out_calc_prog,
         out_calc,
-    }: &SwapExactOutIxAccs<SwapExactOutIxPreKeysOwned, C, D, P>,
-) -> SwapExactOutIxAccs<SwapExactOutIxPreKeysOwned, C::KeysOwned, D::KeysOwned, P::KeysOwned> {
+        pricing_prog,
+        pricing,
+    }: &SwapExactOutIxAccs<[u8; 32], SwapExactOutIxPreKeysOwned, C, D, P>,
+) -> SwapExactOutIxAccs<
+    [u8; 32],
+    SwapExactOutIxPreKeysOwned,
+    C::KeysOwned,
+    D::KeysOwned,
+    P::KeysOwned,
+> {
     IxAccs {
         ix_prefix: *ix_prefix,
+        inp_calc_prog: *inp_calc_prog,
         inp_calc: inp_calc.suf_keys_owned(),
+        out_calc_prog: *out_calc_prog,
         out_calc: out_calc.suf_keys_owned(),
+        pricing_prog: *pricing_prog,
         pricing: pricing.suf_keys_owned(),
     }
 }
 
-/// Use return value with [`super::swap_ix_accs_seq`] to create array
 pub fn swap_exact_out_ix_is_signer<
+    T,
     I,
     C: SolValCalcAccs,
     D: SolValCalcAccs,
@@ -40,18 +51,22 @@ pub fn swap_exact_out_ix_is_signer<
         inp_calc,
         out_calc,
         ..
-    }: &SwapExactOutIxAccs<I, C, D, P>,
-) -> SwapExactOutIxAccs<SwapExactOutIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
+    }: &SwapExactOutIxAccs<T, I, C, D, P>,
+) -> SwapExactOutIxAccs<bool, SwapExactOutIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
     IxAccs {
         ix_prefix: SWAP_EXACT_OUT_IX_PRE_IS_SIGNER,
+        inp_calc_prog: false,
         inp_calc: inp_calc.suf_is_signer(),
+        out_calc_prog: false,
         out_calc: out_calc.suf_is_signer(),
+        pricing_prog: false,
         pricing: pricing.suf_is_signer(),
     }
 }
 
 /// Use return value with [`super::swap_ix_accs_seq`] to create array
 pub fn swap_exact_out_ix_is_writer<
+    T,
     I,
     C: SolValCalcAccs,
     D: SolValCalcAccs,
@@ -62,12 +77,15 @@ pub fn swap_exact_out_ix_is_writer<
         inp_calc,
         out_calc,
         ..
-    }: &SwapExactOutIxAccs<I, C, D, P>,
-) -> SwapExactOutIxAccs<SwapExactOutIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
+    }: &SwapExactOutIxAccs<T, I, C, D, P>,
+) -> SwapExactOutIxAccs<bool, SwapExactOutIxPreAccFlags, C::AccFlags, D::AccFlags, P::AccFlags> {
     IxAccs {
         ix_prefix: SWAP_EXACT_OUT_IX_PRE_IS_WRITER,
+        inp_calc_prog: false,
         inp_calc: inp_calc.suf_is_writer(),
+        out_calc_prog: false,
         out_calc: out_calc.suf_is_writer(),
+        pricing_prog: false,
         pricing: pricing.suf_is_writer(),
     }
 }

--- a/core/src/instructions/swap/mod.rs
+++ b/core/src/instructions/swap/mod.rs
@@ -1,4 +1,7 @@
-use core::{iter::Chain, slice};
+use core::{
+    iter::{once, Chain, Once},
+    slice,
+};
 
 use inf1_ctl_core::instructions::swap as inf1_ctl_core_swap;
 use inf1_svc_core::traits::SolValCalcAccs;
@@ -7,15 +10,18 @@ pub mod exact_in;
 pub mod exact_out;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct IxAccs<I, C, D, P> {
+pub struct IxAccs<T, I, C, D, P> {
     pub ix_prefix: I,
+    pub inp_calc_prog: T,
     pub inp_calc: C,
+    pub out_calc_prog: T,
     pub out_calc: D,
+    pub pricing_prog: T,
     pub pricing: P,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct IxArgs<I, C, D, P> {
+pub struct IxArgs<T, I, C, D, P> {
     pub inp_lst_index: u32,
     pub out_lst_index: u32,
 
@@ -25,10 +31,10 @@ pub struct IxArgs<I, C, D, P> {
 
     pub amount: u64,
 
-    pub accs: IxAccs<I, C, D, P>,
+    pub accs: IxAccs<T, I, C, D, P>,
 }
 
-impl<I, C: SolValCalcAccs, D: SolValCalcAccs, P> IxArgs<I, C, D, P> {
+impl<T, I, C: SolValCalcAccs, D: SolValCalcAccs, P> IxArgs<T, I, C, D, P> {
     #[inline]
     pub fn to_full(&self) -> inf1_ctl_core_swap::IxArgs {
         let Self {
@@ -54,24 +60,36 @@ impl<I, C: SolValCalcAccs, D: SolValCalcAccs, P> IxArgs<I, C, D, P> {
 }
 
 pub type AccsIter<'a, T> = Chain<
-    Chain<Chain<slice::Iter<'a, T>, slice::Iter<'a, T>>, slice::Iter<'a, T>>,
+    Chain<
+        Chain<
+            Chain<Chain<Chain<slice::Iter<'a, T>, Once<&'a T>>, slice::Iter<'a, T>>, Once<&'a T>>,
+            slice::Iter<'a, T>,
+        >,
+        Once<&'a T>,
+    >,
     slice::Iter<'a, T>,
 >;
 
-// Has to be a free fn instead of a IxArgs method otherwise T unconstrained generic
-#[inline]
-pub fn swap_ix_accs_seq<T, I: AsRef<[T]>, C: AsRef<[T]>, D: AsRef<[T]>, P: AsRef<[T]>>(
-    IxAccs {
-        ix_prefix,
-        inp_calc,
-        out_calc,
-        pricing,
-    }: &IxAccs<I, C, D, P>,
-) -> AccsIter<'_, T> {
-    ix_prefix
-        .as_ref()
-        .iter()
-        .chain(inp_calc.as_ref())
-        .chain(out_calc.as_ref())
-        .chain(pricing.as_ref())
+impl<T, I: AsRef<[T]>, C: AsRef<[T]>, D: AsRef<[T]>, P: AsRef<[T]>> IxAccs<T, I, C, D, P> {
+    #[inline]
+    pub fn seq(&self) -> AccsIter<'_, T> {
+        let Self {
+            ix_prefix,
+            inp_calc_prog,
+            inp_calc,
+            out_calc_prog,
+            out_calc,
+            pricing_prog,
+            pricing,
+        } = self;
+        ix_prefix
+            .as_ref()
+            .iter()
+            .chain(once(inp_calc_prog))
+            .chain(inp_calc.as_ref())
+            .chain(once(out_calc_prog))
+            .chain(out_calc.as_ref())
+            .chain(once(pricing_prog))
+            .chain(pricing.as_ref())
+    }
 }


### PR DESCRIPTION
Apply fix for missing program accounts in `*Accs` struct discovered in and applied to Liquidity in https://github.com/igneous-labs/inf-1.5/pull/15  to Swap as well.

Also changed `Chain` iter type to use `Once` instead of `slice::Iter` when iterating through the program accounts, resulting in some wasm bin size reduction