### PR TITLE
TS: ser/de bytevecs as js Uint8Array instead of number[]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "inf1-pp-flatfee-core",
  "inf1-svc-ag",
  "serde",
+ "serde_bytes",
  "tsify-next",
  "wasm-bindgen",
 ]
@@ -390,6 +391,15 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ sanctum-marinade-liquid-staking-core = { git = "https://github.com/igneous-labs/
 sanctum-spl-stake-pool-core = { git = "https://github.com/igneous-labs/sanctum-spl-stake-pool-sdk.git", branch = "master", default-features = false }
 sanctum-u64-ratio = { version = "^1", default-features = false }
 serde = { version = "^1", default-features = false }
+serde_bytes = { version = "^0.11", default-features = false }
 solido-legacy-core = { git = "https://github.com/igneous-labs/solido-legacy-sdk.git", branch = "master", default-features = false }
 tsify-next = { version = "^0.5.5", default-features = false }
 wasm-bindgen = { version = "^0.2", default-features = false }

--- a/ts/sdk/Cargo.toml
+++ b/ts/sdk/Cargo.toml
@@ -3,6 +3,7 @@ name = "inf1" # npm package name without @sanctumso/ scope
 version = "0.0.1-dev-1" # npm package version
 license-file.workspace = true
 edition.workspace = true
+publish = false # this gets published to npm, not crates.io
 
 [lib]
 crate-type = ["cdylib", "rlib"] # required for wasm crate
@@ -16,5 +17,6 @@ inf1-core = { workspace = true }
 inf1-pp-flatfee-core = { workspace = true }
 inf1-svc-ag = { workspace = true }
 serde = { workspace = true }
+serde_bytes = { workspace = true, features = ["alloc"] }
 tsify-next = { workspace = true, features = ["js"] }
 wasm-bindgen = { workspace = true }

--- a/ts/sdk/src/instruction.rs
+++ b/ts/sdk/src/instruction.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
 use tsify_next::Tsify;
 
 use crate::interface::B58PK;
@@ -7,8 +8,7 @@ use crate::interface::B58PK;
 #[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct Instruction {
-    #[tsify(type = "Uint8Array")] // Instead of number[]
-    pub data: Box<[u8]>,
+    pub data: ByteBuf,
     pub accounts: Box<[AccountMeta]>,
     pub program_address: B58PK,
 }

--- a/ts/sdk/src/interface.rs
+++ b/ts/sdk/src/interface.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use bs58_fixed_wasm::Bs58Array;
 use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
 use tsify_next::{declare, Tsify};
 
 #[declare]
@@ -26,8 +27,6 @@ pub struct SplPoolAccounts(pub HashMap<B58PK, B58PK>);
 #[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {
-    #[tsify(type = "Uint8Array")] // Instead of number[]
-    pub data: Box<[u8]>,
-
+    pub data: ByteBuf,
     pub owner: B58PK,
 }

--- a/ts/sdk/src/lib.rs
+++ b/ts/sdk/src/lib.rs
@@ -108,7 +108,7 @@ pub fn init(
 
     Ok(Inf {
         pool,
-        lst_state_list_data: lst_state_list.data,
+        lst_state_list_data: lst_state_list.data.into_vec().into_boxed_slice(),
         lp_token_supply: None,
         pricing: FlatFeePricing::default(),
         lsts: lsts?,
@@ -163,7 +163,7 @@ impl Inf {
         // TODO: maybe cleanup removed LSTs from self.lsts?
 
         self.pool = pool.into_pool_state();
-        self.lst_state_list_data = lst_state_list_acc.data.clone();
+        self.lst_state_list_data = lst_state_list_acc.data.as_slice().into();
 
         Ok(())
     }

--- a/ts/sdk/src/trade/instruction.rs
+++ b/ts/sdk/src/trade/instruction.rs
@@ -41,6 +41,7 @@ use inf1_core::{
 };
 use inf1_svc_ag::inf1_svc_marinade_core::sanctum_marinade_liquid_staking_core::TOKEN_PROGRAM;
 use serde::{Deserialize, Serialize};
+use serde_bytes::ByteBuf;
 use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
@@ -142,18 +143,19 @@ pub fn trade_exact_in_ix(
                 add_liquidity_ix_is_writer(&accs).seq(),
             ),
             program_address: B58PK::new(inf1_ctl_core::ID),
-            data: (*AddLiquidityIxData::new(
-                AddLiquidityIxArgs {
-                    // as-safety: i should not > u32::MAX
-                    lst_index: i as u32,
-                    amount: *amt,
-                    min_out: *limit,
-                    accs,
-                }
-                .to_full(),
-            )
-            .as_buf())
-            .into(),
+            data: ByteBuf::from(
+                AddLiquidityIxData::new(
+                    AddLiquidityIxArgs {
+                        // as-safety: i should not > u32::MAX
+                        lst_index: i as u32,
+                        amount: *amt,
+                        min_out: *limit,
+                        accs,
+                    }
+                    .to_full(),
+                )
+                .as_buf(),
+            ),
         }
     } else if inp_mint == lp_token_mint {
         // remove liquidity
@@ -200,18 +202,19 @@ pub fn trade_exact_in_ix(
                 remove_liquidity_ix_is_writer(&accs).seq(),
             ),
             program_address: B58PK::new(inf1_ctl_core::ID),
-            data: (*RemoveLiquidityIxData::new(
-                RemoveLiquidityIxArgs {
-                    // as-safety: i should not > u32::MAX
-                    lst_index: i as u32,
-                    amount: *amt,
-                    min_out: *limit,
-                    accs,
-                }
-                .to_full(),
-            )
-            .as_buf())
-            .into(),
+            data: ByteBuf::from(
+                RemoveLiquidityIxData::new(
+                    RemoveLiquidityIxArgs {
+                        // as-safety: i should not > u32::MAX
+                        lst_index: i as u32,
+                        amount: *amt,
+                        min_out: *limit,
+                        accs,
+                    }
+                    .to_full(),
+                )
+                .as_buf(),
+            ),
         }
     } else {
         // swap
@@ -275,20 +278,21 @@ pub fn trade_exact_in_ix(
                 swap_exact_in_ix_is_writer(&accs).seq(),
             ),
             program_address: B58PK::new(inf1_ctl_core::ID),
-            data: (*SwapExactInIxData::new(
-                SwapExactInIxArgs {
-                    // as-safety: i should not > u32::MAX
-                    inp_lst_index: inp_i as u32,
-                    out_lst_index: out_i as u32,
+            data: ByteBuf::from(
+                SwapExactInIxData::new(
+                    SwapExactInIxArgs {
+                        // as-safety: i should not > u32::MAX
+                        inp_lst_index: inp_i as u32,
+                        out_lst_index: out_i as u32,
 
-                    limit: *limit,
-                    amount: *amt,
-                    accs,
-                }
-                .to_full(),
-            )
-            .as_buf())
-            .into(),
+                        limit: *limit,
+                        amount: *amt,
+                        accs,
+                    }
+                    .to_full(),
+                )
+                .as_buf(),
+            ),
         }
     };
     Ok(ix)
@@ -387,19 +391,20 @@ pub fn trade_exact_out_ix(
             swap_exact_out_ix_is_writer(&accs).seq(),
         ),
         program_address: B58PK::new(inf1_ctl_core::ID),
-        data: (*SwapExactOutIxData::new(
-            SwapExactOutIxArgs {
-                // as-safety: i should not > u32::MAX
-                inp_lst_index: inp_i as u32,
-                out_lst_index: out_i as u32,
+        data: ByteBuf::from(
+            SwapExactOutIxData::new(
+                SwapExactOutIxArgs {
+                    // as-safety: i should not > u32::MAX
+                    inp_lst_index: inp_i as u32,
+                    out_lst_index: out_i as u32,
 
-                limit: *limit,
-                amount: *amt,
-                accs,
-            }
-            .to_full(),
-        )
-        .as_buf())
-        .into(),
+                    limit: *limit,
+                    amount: *amt,
+                    accs,
+                }
+                .to_full(),
+            )
+            .as_buf(),
+        ),
     })
 }

--- a/ts/tests/README.md
+++ b/ts/tests/README.md
@@ -18,7 +18,7 @@ pnpm install
 Then, start the local test validator with:
 
 ```sh
-docker compose -f ../../docker-compose-local-validator.yml up
+pnpm start:infra
 ```
 
 Then, run the test script with:
@@ -30,7 +30,7 @@ pnpm test
 After tests complete, teardown the local test validator with:
 
 ```sh
-docker compose -f ../../docker-compose-local-validator.yml down
+pnpm stop:infra
 ```
 
 We do not use `package.json`'s `pretest` and `posttest` scripts for this because `posttest` does not run if tests failed and `test` exited with nonzero code.

--- a/ts/tests/package.json
+++ b/ts/tests/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "test": "vitest run",
     "script:eli": "tsx scripts/enable-lst-input.ts",
-    "script:gclus": "tsx scripts/generic-calc-last-update-slot.ts"
+    "script:gclus": "tsx scripts/generic-calc-last-update-slot.ts",
+    "start:infra": "docker compose -f ../../docker-compose-local-validator.yml up -d",
+    "stop:infra": "docker compose -f ../../docker-compose-local-validator.yml down -v"
   },
   "devDependencies": {
     "@sanctumso/inf1": "file:../sdk/pkg",


### PR DESCRIPTION
Previously ran into no issues because Uint8Array's API is sufficiently similar to number[]'s to not notice.

Also updated `Account`'s interface even though we dont strictly need to since we're just deserializing js -> rust, but doing it to make it consistent that all byte buffer interfaces are `Uint8Array <-> ByteBuf`. This also decreases binary sizes by a little bit. 