### PR TITLE
TS bundling: embed base64 encoded wasm

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,9 @@
   "[typescript]": {
     "editor.tabSize": 2
   },
+  "[javascript]": {
+    "editor.tabSize": 2
+  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "rust-analyzer.cargo.features": "all",

--- a/ts/sdk/Makefile
+++ b/ts/sdk/Makefile
@@ -1,9 +1,12 @@
-.DEFAULT_GOAL := nodejs-prod
+# js runtime for executing postbuild.js
+NODE ?= node
 
-nodejs-prod: clean
-	wasm-pack build --target nodejs --release --weak-refs --reference-types --out-name index -s sanctumso
+.DEFAULT_GOAL := postbuild
 
-web-prod: clean
+postbuild: prod
+	cd postbuild && $(NODE) postbuild.mjs
+
+prod: clean
 	wasm-pack build --target web --release --weak-refs --reference-types --out-name index -s sanctumso
 
 clean:

--- a/ts/sdk/README.md
+++ b/ts/sdk/README.md
@@ -22,6 +22,13 @@ import {
   type AccountMap,
   type SplPoolAccounts,
 } from "@sanctumso/inf1";
+import initSdk from "@sanctumso/inf1";
+
+// The SDK needs to be initialized once globally before it can be used (idempotent).
+// For nodejs environments, use
+// `import { initSyncEmbed } from "@sanctumso/inf1"; initSyncEmbed();`
+// instead
+await initSdk();
 
 const LAINESOL = "LAinEtNLgpmCP9Rvsf5Hn8W6EhNiKLZQti1xfWMLy6X";
 const WSOL = "So11111111111111111111111111111111111111112";

--- a/ts/sdk/postbuild/.gitignore
+++ b/ts/sdk/postbuild/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/ts/sdk/postbuild/README.md
+++ b/ts/sdk/postbuild/README.md
@@ -1,0 +1,3 @@
+# postbuild
+
+Post build script for editing `wasm-pack` output to create a package that is usable across nodejs and web.

--- a/ts/sdk/postbuild/package.json
+++ b/ts/sdk/postbuild/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "devDependencies": {
+    "@types/node": "^24.0.3"
+  }
+}

--- a/ts/sdk/postbuild/pnpm-lock.yaml
+++ b/ts/sdk/postbuild/pnpm-lock.yaml
@@ -1,0 +1,29 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.3
+
+packages:
+
+  '@types/node@24.0.3':
+    resolution: {integrity: sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==}
+
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
+snapshots:
+
+  '@types/node@24.0.3':
+    dependencies:
+      undici-types: 7.8.0
+
+  undici-types@7.8.0: {}

--- a/ts/sdk/postbuild/postbuild.mjs
+++ b/ts/sdk/postbuild/postbuild.mjs
@@ -1,0 +1,50 @@
+import { appendFileSync, readFileSync } from "fs";
+
+// Paths
+const PKG_DIR = `${import.meta.dirname}/../pkg`;
+const INDEX_JS_PATH = `${PKG_DIR}/index.js`;
+const INDEX_D_TS_PATH = `${PKG_DIR}/index.d.ts`;
+const INDEX_BG_WASM_PATH = `${PKG_DIR}/index_bg.wasm`;
+
+const WASM_B64_CONST_NAME = "WASM_BIN_B64";
+const INIT_SYNC_EMBED_FN_NAME = "initSyncEmbed";
+
+const CONST_D_TS_APPENDS = `
+/**
+ * Instantiates this \`module\` using the embedded
+ * {@link ${WASM_B64_CONST_NAME}}. This is what works for nodejs envs.
+ *
+ * @returns {InitOutput}
+ */
+export function ${INIT_SYNC_EMBED_FN_NAME}(): InitOutput;
+
+/**
+ * Embedded base64-encoded wasm binary bytes
+ */
+export const ${WASM_B64_CONST_NAME}: string;
+`;
+
+const CONST_INDEX_JS_APPENDS = `
+function ${INIT_SYNC_EMBED_FN_NAME}() {
+  if (wasm !== undefined) return wasm;
+  initSync({ module: Uint8Array.from(atob(${WASM_B64_CONST_NAME}), c => c.charCodeAt(0)) });
+}
+
+export { ${INIT_SYNC_EMBED_FN_NAME} };
+`;
+
+function indexJsWasmEmbedAppend() {
+  const bytes = readFileSync(INDEX_BG_WASM_PATH);
+  const b64 = bytes.toString("base64");
+  return `
+export const ${WASM_B64_CONST_NAME} = "${b64}";
+`;
+}
+
+function main() {
+  appendFileSync(INDEX_D_TS_PATH, CONST_D_TS_APPENDS);
+  appendFileSync(INDEX_JS_PATH, CONST_INDEX_JS_APPENDS);
+  appendFileSync(INDEX_JS_PATH, indexJsWasmEmbedAppend());
+}
+
+main();

--- a/ts/tests/utils/inf.ts
+++ b/ts/tests/utils/inf.ts
@@ -2,6 +2,7 @@ import {
   accountsToUpdateForTrade,
   init,
   initPks,
+  initSyncEmbed,
   updateForTrade,
   type Inf,
   type PkPair,
@@ -20,6 +21,8 @@ export async function infForSwap(
   rpc: Rpc<SolanaRpcApi>,
   swapMints: PkPair
 ): Promise<Inf> {
+  initSyncEmbed();
+
   const { poolState: poolStateAddr, lstStateList: lstStateListAddr } =
     initPks();
   const initAccs = await fetchAccountMap(rpc, [


### PR DESCRIPTION
This PR introduces a `postbuild` js script that edits the output of `wasm-pack --target web` to:
- include the wasm binary as an exported base64 encoded string in `index.js`
- define a new function `initSyncEmbed()` that initializes the module using this string

This creates a single package that can run on both nodejs and web environments. Previously, `--target web` could not run in nodejs due to [undici not being able to fetch via file URL](https://github.com/igneous-labs/sanctum-spl-stake-pool-sdk-INSECURE/issues/16). The package can probably be even ran directly from a `<script>` tag, since now `index.js` is the entire library self-contained.

This approach creates a massive waste of space because the `.wasm` file is now duplicated in `index.js`. Hopefully most bundlers would be able to tree-shake away the base64 string constant if it isn't used.

Full discussion: https://sanctumso.slack.com/archives/C08EFJUJUUF/p1750234558539189