### PR TITLE
TS: rework init

### DIFF
--- a/ts/sdk/README.md
+++ b/ts/sdk/README.md
@@ -15,6 +15,7 @@ import {
 } from "@solana/kit";
 import {
   accountsToUpdateForTrade,
+  init,
   initPks,
   quoteTradeExactIn,
   tradeExactInIx,
@@ -32,11 +33,13 @@ await initSdk();
 
 const LAINESOL = "LAinEtNLgpmCP9Rvsf5Hn8W6EhNiKLZQti1xfWMLy6X";
 const WSOL = "So11111111111111111111111111111111111111112";
-const SPL_POOL_ACCOUNTS: SplPoolAccounts = {
+const SPL_POOL_ACCOUNTS: SplPoolAccounts = new Map(Object.entries({
   [LAINESOL]: "2qyEeSAWKfU18AFthrF7JA8z8ZCi1yt76Tqs917vwQTV",
   // ...populate rest of `spl lst mint: stake pool addr` data
-  // for every single spl lst mint in the INF pool (all 3 spl program deploys)
-};
+  // for every spl lst mints in the INF pool (all 3 spl program deploys).
+  // To support SPL LSTs that are added later on, the `appendSplLsts` fn
+  // can be used to add data
+}));
 
 // If out === INF mint, then below code will work the same,
 // but the quote and instruction will be for AddLiquidity instead of SwapExactIn.
@@ -70,13 +73,10 @@ async function fetchAccountMap(
 const rpc = createSolanaRpc("https://api.mainnet-beta.solana.com");
 
 // init
-const { poolState: poolStateAddr, lstStateList: lstStateListAddr } = initPks();
-const initAccs = await fetchAccountMap(rpc, [poolStateAddr, lstStateListAddr]);
+const ipks = initPks();
+const initAccs = await fetchAccountMap(rpc, ipks);
 const inf = init(
-  {
-    poolState: initAccs.get(poolStateAddr)!,
-    lstStateList: initAccs.get(lstStateListAddr)!,
-  },
+  initAccs,
   SPL_POOL_ACCOUNTS
 );
 

--- a/ts/sdk/src/init.rs
+++ b/ts/sdk/src/init.rs
@@ -1,0 +1,83 @@
+use bs58_fixed_wasm::Bs58Array;
+use inf1_core::inf1_ctl_core::{
+    accounts::{lst_state_list::LstStatePackedList, pool_state::PoolStatePacked},
+    keys::{LST_STATE_LIST_ID, POOL_STATE_ID},
+};
+use serde::{Deserialize, Serialize};
+use tsify_next::Tsify;
+use wasm_bindgen::prelude::*;
+
+use crate::{
+    err::acc_deser_err,
+    interface::{Account, SplPoolAccounts, B58PK},
+    pricing::FlatFeePricing,
+    sol_val_calc::Calc,
+    Inf,
+};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
+#[serde(rename_all = "camelCase")]
+pub struct Init<T> {
+    pub pool_state: T,
+    pub lst_state_list: T,
+}
+
+// need to use a simple newtype here instead of type alias
+// otherwise wasm_bindgen shits itself with missing generics
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
+#[serde(rename_all = "camelCase")]
+pub struct InitPks(Init<B58PK>);
+
+#[wasm_bindgen(js_name = initPks)]
+pub fn init_pks() -> InitPks {
+    InitPks(Init {
+        pool_state: B58PK::new(POOL_STATE_ID),
+        lst_state_list: B58PK::new(LST_STATE_LIST_ID),
+    })
+}
+
+// need to use a simple newtype here instead of type alias
+// otherwise wasm_bindgen shits itself with missing generics
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Tsify)]
+#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
+#[serde(rename_all = "camelCase")]
+pub struct InitAccounts(Init<Account>);
+
+#[wasm_bindgen(js_name = init)]
+pub fn init(
+    InitAccounts(Init {
+        pool_state,
+        lst_state_list,
+    }): InitAccounts,
+    SplPoolAccounts(spl_lsts): SplPoolAccounts,
+) -> Result<Inf, JsError> {
+    let pool = PoolStatePacked::of_acc_data(&pool_state.data)
+        .ok_or_else(|| acc_deser_err(&POOL_STATE_ID))?
+        .into_pool_state();
+    let lst_state_list_packed = LstStatePackedList::of_acc_data(&lst_state_list.data)
+        .ok_or_else(|| acc_deser_err(&LST_STATE_LIST_ID))?;
+    let spl_lsts = spl_lsts
+        .into_iter()
+        .map(|(Bs58Array(k), Bs58Array(v))| (k, v))
+        .collect();
+
+    let lsts: Result<_, JsError> = lst_state_list_packed
+        .0
+        .iter()
+        .map(|s| {
+            let s = s.into_lst_state();
+            Ok((s.mint, (Calc::new(&s, &spl_lsts)?, None)))
+        })
+        .collect();
+
+    Ok(Inf {
+        pool,
+        lst_state_list_data: lst_state_list.data.into_vec().into_boxed_slice(),
+        lp_token_supply: None,
+        pricing: FlatFeePricing::default(),
+        lsts: lsts?,
+        spl_lsts,
+    })
+}

--- a/ts/sdk/src/init.rs
+++ b/ts/sdk/src/init.rs
@@ -45,6 +45,7 @@ pub fn init_pks() -> InitPks {
 #[serde(rename_all = "camelCase")]
 pub struct InitAccounts(Init<Account>);
 
+/// @throws
 #[wasm_bindgen(js_name = init)]
 pub fn init(
     InitAccounts(Init {

--- a/ts/sdk/src/lib.rs
+++ b/ts/sdk/src/lib.rs
@@ -1,33 +1,25 @@
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::HashMap;
 
-use bs58_fixed_wasm::Bs58Array;
 use inf1_core::inf1_ctl_core::{
-    accounts::{
-        lst_state_list::LstStatePackedList,
-        packed_list::PackedList,
-        pool_state::{PoolState, PoolStatePacked},
-    },
-    keys::{LST_STATE_LIST_ID, POOL_STATE_ID},
+    accounts::{lst_state_list::LstStatePackedList, pool_state::PoolState},
     typedefs::lst_state::LstStatePacked,
 };
-use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
 use crate::{
     err::{acc_deser_err, missing_acc_err},
-    interface::{Account, SplPoolAccounts, B58PK},
     pricing::FlatFeePricing,
     sol_val_calc::Calc,
-    utils::token_supply_from_mint_data,
 };
 
 mod err;
+mod init;
 mod instruction;
 mod interface;
 mod pda;
 mod pricing;
 mod sol_val_calc;
+mod spl;
 mod trade;
 mod utils;
 
@@ -49,139 +41,9 @@ pub struct Inf {
     pub(crate) spl_lsts: HashMap<[u8; 32], [u8; 32]>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
-#[serde(rename_all = "camelCase")]
-pub struct Init<T> {
-    pub pool_state: T,
-    pub lst_state_list: T,
-}
-
-// need to use a simple newtype here instead of type alias
-// otherwise wasm_bindgen shits itself with missing generics
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
-#[serde(rename_all = "camelCase")]
-pub struct InitPks(Init<B58PK>);
-
-#[wasm_bindgen(js_name = initPks)]
-pub fn init_pks() -> InitPks {
-    InitPks(Init {
-        pool_state: B58PK::new(POOL_STATE_ID),
-        lst_state_list: B58PK::new(LST_STATE_LIST_ID),
-    })
-}
-
-// need to use a simple newtype here instead of type alias
-// otherwise wasm_bindgen shits itself with missing generics
-#[derive(Debug, Default, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi, large_number_types_as_bigints)]
-#[serde(rename_all = "camelCase")]
-pub struct InitAccounts(Init<Account>);
-
-#[wasm_bindgen(js_name = init)]
-pub fn init(
-    InitAccounts(Init {
-        pool_state,
-        lst_state_list,
-    }): InitAccounts,
-    SplPoolAccounts(spl_lsts): SplPoolAccounts,
-) -> Result<Inf, JsError> {
-    let pool = PoolStatePacked::of_acc_data(&pool_state.data)
-        .ok_or_else(|| acc_deser_err(&POOL_STATE_ID))?
-        .into_pool_state();
-    let lst_state_list_packed = LstStatePackedList::of_acc_data(&lst_state_list.data)
-        .ok_or_else(|| acc_deser_err(&LST_STATE_LIST_ID))?;
-    let spl_lsts = spl_lsts
-        .into_iter()
-        .map(|(Bs58Array(k), Bs58Array(v))| (k, v))
-        .collect();
-
-    let lsts: Result<_, JsError> = lst_state_list_packed
-        .0
-        .iter()
-        .map(|s| {
-            let s = s.into_lst_state();
-            Ok((s.mint, (Calc::new(&s, &spl_lsts)?, None)))
-        })
-        .collect();
-
-    Ok(Inf {
-        pool,
-        lst_state_list_data: lst_state_list.data.into_vec().into_boxed_slice(),
-        lp_token_supply: None,
-        pricing: FlatFeePricing::default(),
-        lsts: lsts?,
-        spl_lsts,
-    })
-}
-
-/// Update SPL LSTs auxiliary data to support new SPL LSTs that may have previously not been covered
-#[wasm_bindgen(js_name = updateSplLsts)]
-pub fn update_spl_lsts(inf: &mut Inf, SplPoolAccounts(spl_lsts): SplPoolAccounts) {
-    inf.spl_lsts = spl_lsts
-        .into_iter()
-        .map(|(Bs58Array(k), Bs58Array(v))| (k, v))
-        .collect();
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Reserves {
     pub balance: u64,
-}
-
-/// Update
-impl Inf {
-    pub(crate) fn update_ctl_accounts(
-        &mut self,
-        fetched: &HashMap<B58PK, Account>,
-    ) -> Result<(), JsError> {
-        let [pool_state_acc, lst_state_list_acc] = [POOL_STATE_ID, LST_STATE_LIST_ID].map(|pk| {
-            fetched
-                .get(&B58PK::new(pk))
-                .ok_or_else(|| missing_acc_err(&pk))
-        });
-        let pool_state_acc = pool_state_acc?;
-        let lst_state_list_acc = lst_state_list_acc?;
-
-        let pool = PoolStatePacked::of_acc_data(&pool_state_acc.data)
-            .ok_or_else(|| acc_deser_err(&POOL_STATE_ID))?;
-        let PackedList(lst_state_list) = LstStatePackedList::of_acc_data(&lst_state_list_acc.data)
-            .ok_or_else(|| acc_deser_err(&LST_STATE_LIST_ID))?;
-        lst_state_list.iter().for_each(|s| {
-            let s = s.into_lst_state();
-            // Initialize sol value calc and indiv LST data if newly added LST
-            if let Entry::Vacant(entry) = self.lsts.entry(s.mint) {
-                // TODO: we are ignoring Calc::new() error here
-                // so that we dont brick our stuff from adding a new unsupported SPL LST.
-                // We maybe want to handle this error properly instead
-                if let Ok(calc) = Calc::new(&s, &self.spl_lsts) {
-                    entry.insert((calc, None));
-                }
-            }
-        });
-        // TODO: maybe cleanup removed LSTs from self.lsts?
-
-        self.pool = pool.into_pool_state();
-        self.lst_state_list_data = lst_state_list_acc.data.as_slice().into();
-
-        Ok(())
-    }
-
-    pub(crate) fn update_lp_token_supply(
-        &mut self,
-        fetched: &HashMap<B58PK, Account>,
-    ) -> Result<(), JsError> {
-        let lp_mint_acc = fetched
-            .get(&B58PK::new(self.pool.lp_token_mint))
-            .ok_or_else(|| missing_acc_err(&self.pool.lp_token_mint))?;
-        let lp_token_supply = token_supply_from_mint_data(&lp_mint_acc.data)
-            .ok_or_else(|| acc_deser_err(&self.pool.lp_token_mint))?;
-
-        self.lp_token_supply = Some(lp_token_supply);
-
-        Ok(())
-    }
 }
 
 /// Accessors

--- a/ts/sdk/src/pda/controller.rs
+++ b/ts/sdk/src/pda/controller.rs
@@ -11,6 +11,7 @@ use crate::{
     pda::{create_raw_pda, find_pda, FoundPda},
 };
 
+/// @throws if not valid PDA found
 #[wasm_bindgen(js_name = findPoolReservesAta)]
 pub fn find_pool_reserves_ata(Bs58Array(mint): &B58PK) -> Result<FoundPda, JsError> {
     let [s1, s2, s3] = pool_reserves_ata_seeds(&TOKEN_PROGRAM, mint);
@@ -19,6 +20,7 @@ pub fn find_pool_reserves_ata(Bs58Array(mint): &B58PK) -> Result<FoundPda, JsErr
         .map(|(pk, b)| FoundPda(B58PK::new(pk), b))
 }
 
+/// @throws if not valid PDA found
 #[wasm_bindgen(js_name = findProtocolFeeAccumulatorAta)]
 pub fn find_protocol_fee_accumulator_ata(Bs58Array(mint): &B58PK) -> Result<FoundPda, JsError> {
     let [s1, s2, s3] = protocol_fee_accumulator_ata_seeds(&TOKEN_PROGRAM, mint);

--- a/ts/sdk/src/pricing.rs
+++ b/ts/sdk/src/pricing.rs
@@ -26,9 +26,12 @@ use crate::{
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct FlatFeePricing {
+    /// `None` when acc not yet fetched
     pub lp_withdrawal_fee_bps: Option<u16>,
 
     /// key=mint
+    ///
+    /// Entry does not exist if acc not yet fetched
     pub lsts: HashMap<[u8; 32], FeeAccount>,
 }
 

--- a/ts/sdk/src/spl.rs
+++ b/ts/sdk/src/spl.rs
@@ -3,7 +3,10 @@
 use bs58_fixed_wasm::Bs58Array;
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use crate::{interface::SplPoolAccounts, Inf};
+use crate::{
+    interface::{SplPoolAccounts, B58PK},
+    Inf,
+};
 
 /// Add SPL LSTs auxiliary data to support new SPL LSTs that may have previously not been covered
 #[wasm_bindgen(js_name = appendSplLsts)]
@@ -13,4 +16,25 @@ pub fn append_spl_lsts(inf: &mut Inf, SplPoolAccounts(spl_lsts): SplPoolAccounts
             .into_iter()
             .map(|(Bs58Array(k), Bs58Array(v))| (k, v)),
     )
+}
+
+/// Returns if the given SPL LST mints have their {@link SplPoolAccounts} present in the object.
+///
+/// Returns a byte array where ret[i] corresponds to the result for `mints[i]`.
+/// 0 - false, 1 - true.
+///
+/// If false is returned, then the data needs to be added via {@link appendSplLsts}
+///
+/// This fn returns a byte array instead of `boolean` array because wasm_bindgen's type
+/// conversion doesnt work with bool arrays.
+#[wasm_bindgen(js_name = hasSplData)]
+pub fn has_spl_data(
+    inf: &Inf,
+    // Clippy complains, needed for wasm_bindgen
+    #[allow(clippy::boxed_local)] mints: Box<[B58PK]>,
+) -> Box<[u8]> {
+    mints
+        .iter()
+        .map(|mint| u8::from(inf.spl_lsts.contains_key(&mint.0)))
+        .collect()
 }

--- a/ts/sdk/src/spl.rs
+++ b/ts/sdk/src/spl.rs
@@ -1,0 +1,15 @@
+//! Special handling of SPL stake pools
+
+use bs58_fixed_wasm::Bs58Array;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::{interface::SplPoolAccounts, Inf};
+
+/// Update SPL LSTs auxiliary data to support new SPL LSTs that may have previously not been covered
+#[wasm_bindgen(js_name = updateSplLsts)]
+pub fn update_spl_lsts(inf: &mut Inf, SplPoolAccounts(spl_lsts): SplPoolAccounts) {
+    inf.spl_lsts = spl_lsts
+        .into_iter()
+        .map(|(Bs58Array(k), Bs58Array(v))| (k, v))
+        .collect();
+}

--- a/ts/sdk/src/spl.rs
+++ b/ts/sdk/src/spl.rs
@@ -5,11 +5,12 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::{interface::SplPoolAccounts, Inf};
 
-/// Update SPL LSTs auxiliary data to support new SPL LSTs that may have previously not been covered
-#[wasm_bindgen(js_name = updateSplLsts)]
-pub fn update_spl_lsts(inf: &mut Inf, SplPoolAccounts(spl_lsts): SplPoolAccounts) {
-    inf.spl_lsts = spl_lsts
-        .into_iter()
-        .map(|(Bs58Array(k), Bs58Array(v))| (k, v))
-        .collect();
+/// Add SPL LSTs auxiliary data to support new SPL LSTs that may have previously not been covered
+#[wasm_bindgen(js_name = appendSplLsts)]
+pub fn append_spl_lsts(inf: &mut Inf, SplPoolAccounts(spl_lsts): SplPoolAccounts) {
+    inf.spl_lsts.extend(
+        spl_lsts
+            .into_iter()
+            .map(|(Bs58Array(k), Bs58Array(v))| (k, v)),
+    )
 }

--- a/ts/sdk/src/trade/instruction.rs
+++ b/ts/sdk/src/trade/instruction.rs
@@ -63,6 +63,7 @@ pub struct TradeArgs {
     pub token_accs: PkPair,
 }
 
+/// @throws
 #[wasm_bindgen(js_name = tradeExactInIx)]
 pub fn trade_exact_in_ix(
     inf: &mut Inf,
@@ -266,6 +267,7 @@ pub fn trade_exact_in_ix(
     Ok(ix)
 }
 
+/// @throws
 #[wasm_bindgen(js_name = tradeExactOutIx)]
 pub fn trade_exact_out_ix(
     inf: &mut Inf,

--- a/ts/sdk/src/trade/instruction.rs
+++ b/ts/sdk/src/trade/instruction.rs
@@ -2,7 +2,6 @@ use bs58_fixed_wasm::Bs58Array;
 use inf1_core::{
     inf1_ctl_core::{
         self,
-        accounts::pool_state::PoolState,
         instructions::{
             liquidity::{
                 add::{AddLiquidityIxData, NewAddLiquidityIxPreAccsBuilder},
@@ -14,7 +13,6 @@ use inf1_core::{
             },
         },
         keys::{LST_STATE_LIST_ID, POOL_STATE_ID},
-        typedefs::lst_state::LstState,
     },
     instructions::{
         liquidity::{
@@ -46,7 +44,6 @@ use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
 use crate::{
-    err::missing_svc_data,
     instruction::{keys_signer_writable_to_metas, Instruction},
     interface::B58PK,
     pda::controller::{create_raw_pool_reserves_ata, create_raw_protocol_fee_accumulator_ata},
@@ -271,7 +268,7 @@ pub fn trade_exact_in_ix(
 
 #[wasm_bindgen(js_name = tradeExactOutIx)]
 pub fn trade_exact_out_ix(
-    inf: &Inf,
+    inf: &mut Inf,
     TradeArgs {
         amt,
         limit,
@@ -289,50 +286,33 @@ pub fn trade_exact_out_ix(
     }: &TradeArgs,
 ) -> Result<Instruction, JsError> {
     // only SwapExactOut is supported for exact out
-    let Inf {
-        pool: PoolState {
-            pricing_program, ..
-        },
-        pricing,
-        lsts,
-        ..
-    } = inf;
-    let lst_state_list = inf.lst_state_list();
-
     // a lot of repeated code with SwapExactIn here,
     // but keeping them for now to allow for decoupled evolution
+    let pricing_prog = inf.pool.pricing_program;
+
+    let pricing = inf.pricing.to_price_swap_accs(&Pair {
+        inp: inp_mint,
+        out: out_mint,
+    });
 
     let [inp_res, out_res]: [Result<_, JsError>; 2] = [inp_mint, out_mint].map(|mint| {
-        let (
-            i,
-            LstState {
-                pool_reserves_bump,
-                protocol_fee_accumulator_bump,
-                sol_value_calculator: calc_addr,
-                ..
-            },
-        ) = try_find_lst_state(lst_state_list, mint)?;
-        let calc = lsts
-            .get(mint)
-            .map(|(c, _)| c.as_sol_val_calc_accs())
-            .ok_or_else(|| missing_svc_data(mint))?;
-        let reserves_addr = create_raw_pool_reserves_ata(mint, pool_reserves_bump);
+        let (i, lst_state) = try_find_lst_state(inf.lst_state_list(), mint)?;
+        let calc = *inf
+            .try_get_or_init_lst(&lst_state)
+            .map(|(c, _)| c.as_sol_val_calc_accs())?;
+        let reserves_addr = create_raw_pool_reserves_ata(mint, lst_state.pool_reserves_bump);
         Ok((
             i,
             calc,
-            calc_addr,
+            lst_state.sol_value_calculator,
             reserves_addr,
-            protocol_fee_accumulator_bump,
+            lst_state.protocol_fee_accumulator_bump,
         ))
     });
     let (inp_i, inp_calc, inp_calc_addr, inp_reserves_addr, _) = inp_res?;
     let (out_i, out_calc, out_calc_addr, out_reserves_addr, out_pf_accum_bump) = out_res?;
     let protocol_fee_accumulator_addr =
         create_raw_protocol_fee_accumulator_ata(out_mint, out_pf_accum_bump);
-    let pricing = pricing.to_price_swap_accs(&Pair {
-        inp: inp_mint,
-        out: out_mint,
-    });
     let accs = SwapExactOutIxAccs {
         ix_prefix: NewSwapExactOutIxPreAccsBuilder::start()
             .with_inp_pool_reserves(inp_reserves_addr)
@@ -352,7 +332,7 @@ pub fn trade_exact_out_ix(
         inp_calc,
         out_calc_prog: out_calc_addr,
         out_calc,
-        pricing_prog: *pricing_program,
+        pricing_prog,
         pricing,
     };
     Ok(Instruction {

--- a/ts/sdk/src/trade/instruction.rs
+++ b/ts/sdk/src/trade/instruction.rs
@@ -68,7 +68,7 @@ pub struct TradeArgs {
 
 #[wasm_bindgen(js_name = tradeExactInIx)]
 pub fn trade_exact_in_ix(
-    inf: &Inf,
+    inf: &mut Inf,
     TradeArgs {
         amt,
         limit,
@@ -85,38 +85,23 @@ pub fn trade_exact_in_ix(
             }),
     }: &TradeArgs,
 ) -> Result<Instruction, JsError> {
-    let Inf {
-        pool:
-            PoolState {
-                lp_token_mint,
-                pricing_program,
-                ..
-            },
-        pricing,
-        lsts,
-        ..
-    } = inf;
-    let lst_state_list = inf.lst_state_list();
+    let lp_token_mint = inf.pool.lp_token_mint;
+    let pricing_prog = inf.pool.pricing_program;
 
-    let ix = if out_mint == lp_token_mint {
+    let ix = if *out_mint == lp_token_mint {
         // add liquidity
-        let (
-            i,
-            LstState {
-                pool_reserves_bump,
-                protocol_fee_accumulator_bump,
-                sol_value_calculator,
-                ..
-            },
-        ) = try_find_lst_state(lst_state_list, inp_mint)?;
-        let inp_calc = lsts
-            .get(inp_mint)
-            .map(|(c, _)| c.as_sol_val_calc_accs())
-            .ok_or_else(|| missing_svc_data(inp_mint))?;
-        let pricing = pricing.to_price_lp_tokens_to_mint_accs();
-        let reserves_addr = create_raw_pool_reserves_ata(inp_mint, pool_reserves_bump);
-        let protocol_fee_accumulator_addr =
-            create_raw_protocol_fee_accumulator_ata(inp_mint, protocol_fee_accumulator_bump);
+        let pricing = inf.pricing.to_price_lp_tokens_to_mint_accs();
+
+        let (i, inp_lst_state) = try_find_lst_state(inf.lst_state_list(), inp_mint)?;
+        let inp_calc = inf
+            .try_get_or_init_lst(&inp_lst_state)
+            .map(|(c, _)| c.as_sol_val_calc_accs())?;
+        let reserves_addr =
+            create_raw_pool_reserves_ata(inp_mint, inp_lst_state.pool_reserves_bump);
+        let protocol_fee_accumulator_addr = create_raw_protocol_fee_accumulator_ata(
+            inp_mint,
+            inp_lst_state.protocol_fee_accumulator_bump,
+        );
         let accs = AddLiquidityIxAccs {
             ix_prefix: NewAddLiquidityIxPreAccsBuilder::start()
                 .with_pool_reserves(reserves_addr)
@@ -131,9 +116,9 @@ pub fn trade_exact_in_ix(
                 .with_lst_state_list(LST_STATE_LIST_ID)
                 .with_pool_state(POOL_STATE_ID)
                 .build(),
-            lst_calc_prog: sol_value_calculator,
+            lst_calc_prog: inp_lst_state.sol_value_calculator,
             lst_calc: inp_calc,
-            pricing_prog: *pricing_program,
+            pricing_prog,
             pricing,
         };
         Instruction {
@@ -157,25 +142,20 @@ pub fn trade_exact_in_ix(
                 .as_buf(),
             ),
         }
-    } else if inp_mint == lp_token_mint {
+    } else if *inp_mint == lp_token_mint {
         // remove liquidity
-        let (
-            i,
-            LstState {
-                pool_reserves_bump,
-                protocol_fee_accumulator_bump,
-                sol_value_calculator,
-                ..
-            },
-        ) = try_find_lst_state(lst_state_list, out_mint)?;
-        let out_calc = lsts
-            .get(out_mint)
-            .map(|(c, _)| c.as_sol_val_calc_accs())
-            .ok_or_else(|| missing_svc_data(out_mint))?;
-        let pricing = pricing.to_price_lp_tokens_to_redeem_accs();
-        let reserves_addr = create_raw_pool_reserves_ata(out_mint, pool_reserves_bump);
-        let protocol_fee_accumulator_addr =
-            create_raw_protocol_fee_accumulator_ata(out_mint, protocol_fee_accumulator_bump);
+        let pricing = inf.pricing.to_price_lp_tokens_to_redeem_accs();
+
+        let (i, out_lst_state) = try_find_lst_state(inf.lst_state_list(), out_mint)?;
+        let out_calc = inf
+            .try_get_or_init_lst(&out_lst_state)
+            .map(|(c, _)| c.as_sol_val_calc_accs())?;
+        let reserves_addr =
+            create_raw_pool_reserves_ata(out_mint, out_lst_state.pool_reserves_bump);
+        let protocol_fee_accumulator_addr = create_raw_protocol_fee_accumulator_ata(
+            out_mint,
+            out_lst_state.protocol_fee_accumulator_bump,
+        );
         let accs = RemoveLiquidityIxAccs {
             ix_prefix: NewRemoveLiquidityIxPreAccsBuilder::start()
                 .with_pool_reserves(reserves_addr)
@@ -190,9 +170,9 @@ pub fn trade_exact_in_ix(
                 .with_lst_state_list(LST_STATE_LIST_ID)
                 .with_pool_state(POOL_STATE_ID)
                 .build(),
-            lst_calc_prog: sol_value_calculator,
+            lst_calc_prog: out_lst_state.sol_value_calculator,
             lst_calc: out_calc,
-            pricing_prog: *pricing_program,
+            pricing_prog,
             pricing,
         };
         Instruction {
@@ -218,37 +198,28 @@ pub fn trade_exact_in_ix(
         }
     } else {
         // swap
+        let pricing = inf.pricing.to_price_swap_accs(&Pair {
+            inp: inp_mint,
+            out: out_mint,
+        });
         let [inp_res, out_res]: [Result<_, JsError>; 2] = [inp_mint, out_mint].map(|mint| {
-            let (
-                i,
-                LstState {
-                    pool_reserves_bump,
-                    protocol_fee_accumulator_bump,
-                    sol_value_calculator: calc_addr,
-                    ..
-                },
-            ) = try_find_lst_state(lst_state_list, mint)?;
-            let calc = lsts
-                .get(mint)
-                .map(|(c, _)| c.as_sol_val_calc_accs())
-                .ok_or_else(|| missing_svc_data(mint))?;
-            let reserves_addr = create_raw_pool_reserves_ata(mint, pool_reserves_bump);
+            let (i, lst_state) = try_find_lst_state(inf.lst_state_list(), mint)?;
+            let calc = *inf
+                .try_get_or_init_lst(&lst_state)
+                .map(|(c, _)| c.as_sol_val_calc_accs())?;
+            let reserves_addr = create_raw_pool_reserves_ata(mint, lst_state.pool_reserves_bump);
             Ok((
                 i,
                 calc,
-                calc_addr,
+                lst_state.sol_value_calculator,
                 reserves_addr,
-                protocol_fee_accumulator_bump,
+                lst_state.protocol_fee_accumulator_bump,
             ))
         });
         let (inp_i, inp_calc, inp_calc_addr, inp_reserves_addr, _) = inp_res?;
         let (out_i, out_calc, out_calc_addr, out_reserves_addr, out_pf_accum_bump) = out_res?;
         let protocol_fee_accumulator_addr =
             create_raw_protocol_fee_accumulator_ata(out_mint, out_pf_accum_bump);
-        let pricing = pricing.to_price_swap_accs(&Pair {
-            inp: inp_mint,
-            out: out_mint,
-        });
         let accs = SwapExactInIxAccs {
             ix_prefix: NewSwapExactInIxPreAccsBuilder::start()
                 .with_inp_pool_reserves(inp_reserves_addr)
@@ -268,7 +239,7 @@ pub fn trade_exact_in_ix(
             inp_calc,
             out_calc_prog: out_calc_addr,
             out_calc,
-            pricing_prog: *pricing_program,
+            pricing_prog,
             pricing,
         };
         Instruction {

--- a/ts/sdk/src/trade/quote.rs
+++ b/ts/sdk/src/trade/quote.rs
@@ -74,6 +74,7 @@ pub struct Quote {
     pub mints: PkPair,
 }
 
+/// @throws
 #[wasm_bindgen(js_name = quoteTradeExactIn)]
 pub fn quote_trade_exact_in(
     inf: &mut Inf,
@@ -235,6 +236,7 @@ pub fn quote_trade_exact_in(
     Ok(quote)
 }
 
+/// @throws
 #[wasm_bindgen(js_name = quoteTradeExactOut)]
 pub fn quote_trade_exact_out(
     inf: &mut Inf,

--- a/ts/sdk/src/trade/update.rs
+++ b/ts/sdk/src/trade/update.rs
@@ -84,6 +84,7 @@ pub fn accounts_to_update_for_trade(
     Ok(res.into_boxed_slice())
 }
 
+/// @throws
 #[wasm_bindgen(js_name = updateForTrade)]
 pub fn update_for_trade(
     inf: &mut Inf,

--- a/ts/sdk/src/trade/update.rs
+++ b/ts/sdk/src/trade/update.rs
@@ -1,24 +1,17 @@
-use std::collections::{hash_map::Entry, HashMap};
+use std::{collections::HashMap, iter};
 
 use bs58_fixed_wasm::Bs58Array;
 use inf1_core::inf1_ctl_core::{
-    accounts::{
-        lst_state_list::LstStatePackedList,
-        packed_list::PackedList,
-        pool_state::{PoolState, PoolStatePacked},
-    },
+    accounts::pool_state::PoolStatePacked,
     keys::{LST_STATE_LIST_ID, POOL_STATE_ID},
-    typedefs::lst_state::LstState,
 };
 use wasm_bindgen::prelude::*;
 
 use crate::{
     acc_deser_err,
-    err::missing_spl_data,
     interface::{Account, AccountMap, B58PK},
     missing_acc_err,
     pda::controller::create_raw_pool_reserves_ata,
-    sol_val_calc::Calc,
     trade::{Pair, PkPair},
     utils::{balance_from_token_acc_data, token_supply_from_mint_data, try_find_lst_state},
     Inf, Reserves,
@@ -29,81 +22,59 @@ use crate::{
 /// @throws
 #[wasm_bindgen(js_name = accountsToUpdateForTrade)]
 pub fn accounts_to_update_for_trade(
-    inf: &Inf,
+    inf: &mut Inf,
     PkPair(Pair {
         inp: Bs58Array(inp),
         out: Bs58Array(out),
     }): &PkPair,
 ) -> Result<Box<[B58PK]>, JsError> {
-    let Inf {
-        pool: PoolState { lp_token_mint, .. },
-        lsts,
-        pricing,
-        ..
-    } = inf;
-    let lst_state_list = inf.lst_state_list();
-
     let mut res = vec![B58PK::new(POOL_STATE_ID), B58PK::new(LST_STATE_LIST_ID)];
 
-    if out == lp_token_mint {
+    let lp_token_mint = inf.pool.lp_token_mint;
+    if *out == lp_token_mint {
         // add liquidity
-        let (
-            _i,
-            LstState {
-                pool_reserves_bump, ..
-            },
-        ) = try_find_lst_state(lst_state_list, inp)?;
-        let (calc, _) = lsts.get(inp).ok_or_else(|| missing_spl_data(inp))?;
+        let (_i, lst_state) = try_find_lst_state(inf.lst_state_list(), inp)?;
+        let (calc, _) = inf.try_get_or_init_lst(&lst_state)?;
         res.extend(
             calc.accounts_to_update()
                 .copied()
                 .chain([
-                    *lp_token_mint,
-                    create_raw_pool_reserves_ata(inp, pool_reserves_bump),
+                    lp_token_mint,
+                    create_raw_pool_reserves_ata(inp, lst_state.pool_reserves_bump),
                 ])
                 .map(B58PK::new),
         );
-    } else if inp == lp_token_mint {
+    } else if *inp == lp_token_mint {
         // remove liquidity
-        let (
-            _i,
-            LstState {
-                pool_reserves_bump, ..
-            },
-        ) = try_find_lst_state(lst_state_list, out)?;
-        let (calc, _) = lsts.get(out).ok_or_else(|| missing_spl_data(out))?;
+        let pricing_acc = inf.pricing.account_to_update_remove_liquidity();
+        let (_i, lst_state) = try_find_lst_state(inf.lst_state_list(), out)?;
+        let (calc, _) = inf.try_get_or_init_lst(&lst_state)?;
         res.extend(
             calc.accounts_to_update()
                 .copied()
                 .chain([
-                    *lp_token_mint,
-                    pricing.account_to_update_remove_liquidity(),
-                    create_raw_pool_reserves_ata(out, pool_reserves_bump),
+                    pricing_acc,
+                    lp_token_mint,
+                    create_raw_pool_reserves_ata(out, lst_state.pool_reserves_bump),
                 ])
                 .map(B58PK::new),
         );
     } else {
         // swap
-        let [inp_res, out_res]: [Result<_, JsError>; 2] = [inp, out].map(|mint| {
-            let (
-                _i,
-                LstState {
-                    pool_reserves_bump, ..
-                },
-            ) = try_find_lst_state(lst_state_list, mint)?;
-            let reserves = create_raw_pool_reserves_ata(mint, pool_reserves_bump);
-            let (calc, _) = lsts.get(mint).ok_or_else(|| missing_spl_data(mint))?;
-            Ok((calc, reserves))
-        });
-        let (inp_calc, inp_reserves) = inp_res?;
-        let (out_calc, out_reserves) = out_res?;
+        for mint in [inp, out] {
+            let (_i, lst_state) = try_find_lst_state(inf.lst_state_list(), mint)?;
+            let (calc, _) = inf.try_get_or_init_lst(&lst_state)?;
+            let reserves_addr = create_raw_pool_reserves_ata(mint, lst_state.pool_reserves_bump);
+            res.extend(
+                calc.accounts_to_update()
+                    .copied()
+                    .chain(iter::once(reserves_addr))
+                    .map(B58PK::new),
+            );
+        }
         res.extend(
-            inp_calc
-                .accounts_to_update()
-                .copied()
-                .chain(out_calc.accounts_to_update().copied())
-                .chain(pricing.accounts_to_update_swap([inp, out]))
-                .chain([inp_reserves, out_reserves])
+            inf.pricing
+                .accounts_to_update_swap([inp, out])
                 .map(B58PK::new),
         );
     };
@@ -126,87 +97,25 @@ pub fn update_for_trade(
     if *out == inf.pool.lp_token_mint {
         // add liquidity
         inf.update_lp_token_supply(fetched)?;
-
-        let (
-            _i,
-            LstState {
-                pool_reserves_bump, ..
-            },
-        ) = try_find_lst_state(inf.lst_state_list(), inp)?;
-        let reserves_addr = create_raw_pool_reserves_ata(inp, pool_reserves_bump);
-        let (calc, reserves) = inf.lsts.get_mut(inp).ok_or_else(|| missing_spl_data(inp))?;
-
-        calc.update(fetched)?;
-
-        update_reserves(reserves, reserves_addr, fetched)?;
+        inf.update_lst(inp, fetched)?;
     } else if *inp == inf.pool.lp_token_mint {
         // remove liquidity
         inf.update_lp_token_supply(fetched)?;
-
-        let (
-            _i,
-            LstState {
-                pool_reserves_bump, ..
-            },
-        ) = try_find_lst_state(inf.lst_state_list(), out)?;
-        let reserves_addr = create_raw_pool_reserves_ata(out, pool_reserves_bump);
-        let (calc, reserves) = inf.lsts.get_mut(out).ok_or_else(|| missing_spl_data(out))?;
-
-        calc.update(fetched)?;
-
-        update_reserves(reserves, reserves_addr, fetched)?;
-
+        inf.update_lst(out, fetched)?;
         inf.pricing.update_remove_liquidity(fetched)?;
     } else {
         // swap
         [inp, out]
             .iter()
-            .try_for_each::<_, Result<(), JsError>>(|mint| {
-                let (
-                    _i,
-                    LstState {
-                        pool_reserves_bump, ..
-                    },
-                ) = try_find_lst_state(inf.lst_state_list(), mint)?;
-                let reserves_addr = create_raw_pool_reserves_ata(mint, pool_reserves_bump);
-                let (calc, reserves) = inf
-                    .lsts
-                    .get_mut(*mint)
-                    .ok_or_else(|| missing_spl_data(mint))?;
-
-                calc.update(fetched)?;
-
-                update_reserves(reserves, reserves_addr, fetched)?;
-
-                Ok(())
-            })?;
-
+            .try_for_each::<_, Result<(), JsError>>(|mint| inf.update_lst(mint, fetched))?;
         inf.pricing.update_swap([inp, out], fetched)?;
     };
 
     Ok(())
 }
 
-fn update_reserves(
-    reserves: &mut Option<Reserves>,
-    reserves_addr: [u8; 32],
-    fetched: &HashMap<B58PK, Account>,
-) -> Result<(), JsError> {
-    let token_acc = fetched
-        .get(&B58PK::new(reserves_addr))
-        .ok_or_else(|| missing_acc_err(&reserves_addr))?;
-    *reserves = Some(Reserves {
-        balance: balance_from_token_acc_data(&token_acc.data)
-            .ok_or_else(|| acc_deser_err(&reserves_addr))?,
-    });
-    Ok(())
-}
-
 impl Inf {
-    pub(crate) fn update_ctl_accounts(
-        &mut self,
-        fetched: &HashMap<B58PK, Account>,
-    ) -> Result<(), JsError> {
+    fn update_ctl_accounts(&mut self, fetched: &HashMap<B58PK, Account>) -> Result<(), JsError> {
         let [pool_state_acc, lst_state_list_acc] = [POOL_STATE_ID, LST_STATE_LIST_ID].map(|pk| {
             fetched
                 .get(&B58PK::new(pk))
@@ -217,32 +126,16 @@ impl Inf {
 
         let pool = PoolStatePacked::of_acc_data(&pool_state_acc.data)
             .ok_or_else(|| acc_deser_err(&POOL_STATE_ID))?;
-        let PackedList(lst_state_list) = LstStatePackedList::of_acc_data(&lst_state_list_acc.data)
-            .ok_or_else(|| acc_deser_err(&LST_STATE_LIST_ID))?;
-        lst_state_list.iter().for_each(|s| {
-            let s = s.into_lst_state();
-            // Initialize sol value calc and indiv LST data if newly added LST
-            if let Entry::Vacant(entry) = self.lsts.entry(s.mint) {
-                // TODO: we are ignoring Calc::new() error here
-                // so that we dont brick our stuff from adding a new unsupported SPL LST.
-                // We maybe want to handle this error properly instead
-                if let Ok(calc) = Calc::new(&s, &self.spl_lsts) {
-                    entry.insert((calc, None));
-                }
-            }
-        });
-        // TODO: maybe cleanup removed LSTs from self.lsts?
 
         self.pool = pool.into_pool_state();
         self.lst_state_list_data = lst_state_list_acc.data.as_slice().into();
 
+        // TODO: maybe cleanup removed LSTs from self.lsts?
+
         Ok(())
     }
 
-    pub(crate) fn update_lp_token_supply(
-        &mut self,
-        fetched: &HashMap<B58PK, Account>,
-    ) -> Result<(), JsError> {
+    fn update_lp_token_supply(&mut self, fetched: &HashMap<B58PK, Account>) -> Result<(), JsError> {
         let lp_mint_acc = fetched
             .get(&B58PK::new(self.pool.lp_token_mint))
             .ok_or_else(|| missing_acc_err(&self.pool.lp_token_mint))?;
@@ -251,6 +144,35 @@ impl Inf {
 
         self.lp_token_supply = Some(lp_token_supply);
 
+        Ok(())
+    }
+
+    fn update_lst(
+        &mut self,
+        mint: &[u8; 32],
+        fetched: &HashMap<B58PK, Account>,
+    ) -> Result<(), JsError> {
+        let (_i, lst_state) = try_find_lst_state(self.lst_state_list(), mint)?;
+        let reserves_addr = create_raw_pool_reserves_ata(mint, lst_state.pool_reserves_bump);
+        let (calc, reserves) = self.try_get_or_init_lst(&lst_state)?;
+        calc.update(fetched)?;
+        Reserves::update(reserves, reserves_addr, fetched)
+    }
+}
+
+impl Reserves {
+    fn update(
+        reserves: &mut Option<Reserves>,
+        reserves_addr: [u8; 32],
+        fetched: &HashMap<B58PK, Account>,
+    ) -> Result<(), JsError> {
+        let token_acc = fetched
+            .get(&B58PK::new(reserves_addr))
+            .ok_or_else(|| missing_acc_err(&reserves_addr))?;
+        *reserves = Some(Reserves {
+            balance: balance_from_token_acc_data(&token_acc.data)
+                .ok_or_else(|| acc_deser_err(&reserves_addr))?,
+        });
         Ok(())
     }
 }

--- a/ts/tests/test/append-spl-lsts.test.ts
+++ b/ts/tests/test/append-spl-lsts.test.ts
@@ -1,0 +1,58 @@
+import {
+  accountsToUpdateForTrade,
+  appendSplLsts,
+  init,
+  initPks,
+  initSyncEmbed,
+  quoteTradeExactIn,
+  tradeExactInIx,
+  updateForTrade,
+} from "@sanctumso/inf1";
+import { beforeAll, describe, expect, it } from "vitest";
+import { fetchAccountMap, JUPSOL_MINT, localRpc, WSOL_MINT } from "../utils";
+
+const JUPSOL_POOL = "8VpRhuxa7sUUepdY3kQiTmX9rS5vx4WgaXiAnXq4KCtr";
+
+describe("appendSplLsts test", async () => {
+  beforeAll(() => initSyncEmbed());
+
+  it("Inf able to quote for SPL LST after adding data", async () => {
+    const rpc = localRpc();
+    const pks = initPks();
+    const initAccs = await fetchAccountMap(rpc, pks);
+    // init with empty SplPoolAccounts
+    const inf = init(initAccs, new Map());
+    const mints = {
+      inp: WSOL_MINT,
+      out: JUPSOL_MINT,
+    };
+    expect(() => accountsToUpdateForTrade(inf, mints)).toThrowError();
+
+    const newSplLsts = new Map();
+    newSplLsts.set(JUPSOL_MINT, JUPSOL_POOL);
+    appendSplLsts(inf, newSplLsts);
+
+    // now stuff should work. fns below that perform full
+    // update -> quote -> instruction cycle should not throw
+    const updateAccs = await fetchAccountMap(
+      rpc,
+      accountsToUpdateForTrade(inf, mints)
+    );
+    updateForTrade(inf, mints, updateAccs);
+    const quote = { amt: 1_000_000_000n, mints };
+    quoteTradeExactIn(inf, quote);
+    tradeExactInIx(inf, {
+      limit: 1_000_000_000n,
+      ...quote,
+
+      // dont care abt these pubkeys,
+      // we just wanna make sure the ix function
+      // doesnt throw for this test here
+      signer: JUPSOL_POOL,
+      tokenAccs: {
+        inp: JUPSOL_POOL,
+        out: JUPSOL_POOL,
+      },
+    });
+  });
+});

--- a/ts/tests/test/spl-utils.test.ts
+++ b/ts/tests/test/spl-utils.test.ts
@@ -1,6 +1,8 @@
 import {
   accountsToUpdateForTrade,
   appendSplLsts,
+  hasSplData,
+  Inf,
   init,
   initPks,
   initSyncEmbed,
@@ -9,19 +11,31 @@ import {
   updateForTrade,
 } from "@sanctumso/inf1";
 import { beforeAll, describe, expect, it } from "vitest";
-import { fetchAccountMap, JUPSOL_MINT, localRpc, WSOL_MINT } from "../utils";
+import {
+  fetchAccountMap,
+  JUPSOL_MINT,
+  LAINESOL_MINT,
+  localRpc,
+  WSOL_MINT,
+} from "../utils";
+import type { Rpc, SolanaRpcApi } from "@solana/kit";
 
 const JUPSOL_POOL = "8VpRhuxa7sUUepdY3kQiTmX9rS5vx4WgaXiAnXq4KCtr";
+
+async function emptySplInf(rpc: Rpc<SolanaRpcApi>): Promise<Inf> {
+  const pks = initPks();
+  const initAccs = await fetchAccountMap(rpc, pks);
+  // init with empty SplPoolAccounts
+  return init(initAccs, new Map());
+}
 
 describe("appendSplLsts test", async () => {
   beforeAll(() => initSyncEmbed());
 
   it("Inf able to quote for SPL LST after adding data", async () => {
     const rpc = localRpc();
-    const pks = initPks();
-    const initAccs = await fetchAccountMap(rpc, pks);
-    // init with empty SplPoolAccounts
-    const inf = init(initAccs, new Map());
+    const inf = await emptySplInf(rpc);
+
     const mints = {
       inp: WSOL_MINT,
       out: JUPSOL_MINT,
@@ -54,5 +68,23 @@ describe("appendSplLsts test", async () => {
         out: JUPSOL_POOL,
       },
     });
+  });
+
+  it("hasSplData set from false to true by adding data", async () => {
+    const rpc = localRpc();
+    const inf = await emptySplInf(rpc);
+    const mints = [JUPSOL_MINT, LAINESOL_MINT];
+
+    expect(hasSplData(inf, mints)).toStrictEqual(
+      new Uint8Array(Array.from({ length: mints.length }, () => 0))
+    );
+
+    const newSplLsts = new Map();
+    newSplLsts.set(JUPSOL_MINT, JUPSOL_POOL);
+    appendSplLsts(inf, newSplLsts);
+
+    const d = hasSplData(inf, mints);
+    expect(d[0]).toStrictEqual(1);
+    expect(d[1]).toStrictEqual(0);
   });
 });

--- a/ts/tests/utils/inf.ts
+++ b/ts/tests/utils/inf.ts
@@ -23,19 +23,9 @@ export async function infForSwap(
 ): Promise<Inf> {
   initSyncEmbed();
 
-  const { poolState: poolStateAddr, lstStateList: lstStateListAddr } =
-    initPks();
-  const initAccs = await fetchAccountMap(rpc, [
-    poolStateAddr,
-    lstStateListAddr,
-  ]);
-  const inf = init(
-    {
-      poolState: initAccs.get(poolStateAddr)!,
-      lstStateList: initAccs.get(lstStateListAddr)!,
-    },
-    SPL_POOL_ACCOUNTS
-  );
+  const pks = initPks();
+  const initAccs = await fetchAccountMap(rpc, pks);
+  const inf = init(initAccs, SPL_POOL_ACCOUNTS);
   const updateAccs = await fetchAccountMap(
     rpc,
     accountsToUpdateForTrade(inf, swapMints)

--- a/ts/tests/utils/token.ts
+++ b/ts/tests/utils/token.ts
@@ -19,6 +19,9 @@ export const WSOL_MINT = address("So11111111111111111111111111111111111111112");
 export const JUPSOL_MINT = address(
   "jupSoLaHXQiZZTSfEWMTRRgpnyFm8f6sZdosWBjx93v"
 );
+export const LAINESOL_MINT = address(
+  "LAinEtNLgpmCP9Rvsf5Hn8W6EhNiKLZQti1xfWMLy6X"
+);
 export const MSOL_MINT = address("mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So");
 export const STSOL_MINT = address(
   "7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj"


### PR DESCRIPTION
# Description

This PR is in the spirit of https://github.com/igneous-labs/sanctum-router-sdk/pull/33. Although INF doesnt fetch all SPL pool acounts like router, the eager initialization of `Calc` state for all LSTs in the list means that all SPL init data needs to be provided upfront. This is rectified by the introduction of the `try_get_or_init_lst()` function that lazily initializes state for an individual LST when needed, thereby allowing SPL LSTs we have incomplete data of to remain inert on the list so that we dont need to provide all data upfront. 

There was previously also no way to update the SPL init data, preventing new LSTs that were added after initialization of the object from functioning. The new js function `appendSplLsts()` fills in this functionality, while `hasSplData()` allows users to check which SPL LSTs require their data to be passed in via `appendSplLsts()`. 

Unfortunately, we aren't able to completely remove account fetching for init(), which would completely remove redundant work with `update()` (`update()` usually requires fetching accounts that were previously just used to `init()` the `Inf` object): 
- we need LST state list account data immediately after init() to run the lazy initialization mentioned above and determine what kind of LST a inp/out mint, which sol val calc program its using, and therefore the appropriate accounts to fetch for update
- we need PoolState account data immediately after init() to get LP token mint (tho we could technically hardcode this for mainnet)

# Additional Notes
- The `init` and `initPks` APIs have been modified to take `AccountMap` as arg and return `B58PK[]` respectively, instead of using its own `Init<T>` type, in order to facilitate code reuse between init and update procedures
- All fallible js functions now annotated with jsdoc `@throws`  

