### PR TITLE
[A25SAN1-6] clamp range of `fee_nanos`

### DIFF
--- a/pricing/flatslab/core/src/accounts.rs
+++ b/pricing/flatslab/core/src/accounts.rs
@@ -3,6 +3,9 @@ use core::mem::size_of;
 use crate::typedefs::{SlabEntryPacked, SlabEntryPackedList, SlabEntryPackedListMut};
 
 // `.0` - full account data
+/// # Invariants
+/// - [`crate::keys::LP_MINT_ID`] is always an entry in `Slab` account
+/// - Because of above, length of slab entries >= 1
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct Slab<'a>(&'a [u8]);
 

--- a/pricing/flatslab/core/src/accounts.rs
+++ b/pricing/flatslab/core/src/accounts.rs
@@ -114,6 +114,8 @@ impl SlabMut<'_> {
 mod tests {
     use proptest::{collection::vec, prelude::*};
 
+    use crate::typedefs::FeeNanos;
+
     use super::*;
 
     prop_compose! {
@@ -140,8 +142,8 @@ mod tests {
         fn slab_general_mutate_then_check((mut data, edit_idx) in rand_slab_params()) {
             const SET_MAN_TO: [u8; 32] = [1u8; 32];
             const SET_MINT_TO: [u8; 32] = [69u8; 32];
-            const SET_INP_FEE_NANOS_TO: i32 = i32::MIN;
-            const SET_OUT_FEE_NANOS_TO: i32 = i32::MAX;
+            const SET_INP_FEE_NANOS_TO: FeeNanos = FeeNanos::MIN;
+           const SET_OUT_FEE_NANOS_TO: FeeNanos = FeeNanos::MAX;
 
             let deser = Slab::of_acc_data(&data);
             let should_be_valid = data.len() >= 32 && (data.len() - 32) % size_of::<SlabEntryPacked>() == 0;

--- a/pricing/flatslab/core/src/errs.rs
+++ b/pricing/flatslab/core/src/errs.rs
@@ -4,17 +4,18 @@ use crate::{pricing::FlatSlabPricingErr, typedefs::MintNotFoundErr};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FlatSlabProgramErr {
+    CantRemoveLpMint,
     MintNotFound(MintNotFoundErr),
     MissingAdminSignature,
     Pricing(FlatSlabPricingErr),
     WrongSlabAcc,
-    // TODO: add more variants as needed
 }
 
 impl Display for FlatSlabProgramErr {
     #[inline]
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            Self::CantRemoveLpMint => f.write_str("CantRemoveLpMint"),
             Self::MintNotFound(e) => Display::fmt(&e, f),
             Self::MissingAdminSignature => f.write_str("MissingAdminSignature"),
             Self::Pricing(e) => Display::fmt(&e, f),

--- a/pricing/flatslab/core/src/errs.rs
+++ b/pricing/flatslab/core/src/errs.rs
@@ -1,10 +1,14 @@
 use core::{error::Error, fmt::Display};
 
-use crate::{pricing::FlatSlabPricingErr, typedefs::MintNotFoundErr};
+use crate::{
+    pricing::FlatSlabPricingErr,
+    typedefs::{FeeNanosOutOfRangeErr, MintNotFoundErr},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FlatSlabProgramErr {
     CantRemoveLpMint,
+    FeeNanosOutOfRange(FeeNanosOutOfRangeErr),
     MintNotFound(MintNotFoundErr),
     MissingAdminSignature,
     Pricing(FlatSlabPricingErr),
@@ -16,6 +20,7 @@ impl Display for FlatSlabProgramErr {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::CantRemoveLpMint => f.write_str("CantRemoveLpMint"),
+            Self::FeeNanosOutOfRange(e) => Display::fmt(&e, f),
             Self::MintNotFound(e) => Display::fmt(&e, f),
             Self::MissingAdminSignature => f.write_str("MissingAdminSignature"),
             Self::Pricing(e) => Display::fmt(&e, f),

--- a/pricing/flatslab/core/src/typedefs.rs
+++ b/pricing/flatslab/core/src/typedefs.rs
@@ -21,7 +21,10 @@ pub struct FeeNanos(i32);
 
 /// Constructors
 impl FeeNanos {
+    /// -5%
     pub const MIN: Self = Self(MIN_FEE_NANOS);
+
+    /// 100%
     pub const MAX: Self = Self(MAX_FEE_NANOS);
 
     #[inline]

--- a/pricing/flatslab/core/src/typedefs.rs
+++ b/pricing/flatslab/core/src/typedefs.rs
@@ -1,4 +1,4 @@
-use core::{error::Error, fmt::Display, slice};
+use core::{error::Error, fmt::Display, ops::Deref, slice};
 
 use inf1_pp_core::pair::Pair;
 
@@ -7,6 +7,68 @@ use crate::{
     pricing::FlatSlabSwapPricing,
 };
 
+pub const NANOS_DENOM: i32 = 1_000_000_000;
+
+/// -5%
+pub const MIN_FEE_NANOS: i32 = -50_000_000;
+
+/// 100%
+pub const MAX_FEE_NANOS: i32 = NANOS_DENOM;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct FeeNanos(i32);
+
+/// Constructors
+impl FeeNanos {
+    pub const MIN: Self = Self(MIN_FEE_NANOS);
+    pub const MAX: Self = Self(MAX_FEE_NANOS);
+
+    #[inline]
+    pub const fn new(n: i32) -> Result<Self, FeeNanosOutOfRangeErr> {
+        if n > MAX_FEE_NANOS || n < MIN_FEE_NANOS {
+            Err(FeeNanosOutOfRangeErr { actual: n })
+        } else {
+            Ok(Self(n))
+        }
+    }
+
+    #[inline]
+    pub const fn get(&self) -> i32 {
+        self.0
+    }
+}
+
+impl Deref for FeeNanos {
+    type Target = i32;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FeeNanosOutOfRangeErr {
+    pub actual: i32,
+}
+
+impl Display for FeeNanosOutOfRangeErr {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let Self { actual } = self;
+        if self.actual > MAX_FEE_NANOS {
+            f.write_fmt(format_args!("fee nanos {actual} > {MAX_FEE_NANOS} (max)"))
+        } else {
+            f.write_fmt(format_args!("fee nanos {actual} < {MIN_FEE_NANOS} (min)"))
+        }
+    }
+}
+
+impl Error for FeeNanosOutOfRangeErr {}
+
+/// # Invariants
+/// - `inp_fee_nanos` and `out_fee_nanos` must be of valid [`FeeNanos`] (in range)
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SlabEntryPacked {
@@ -39,13 +101,13 @@ impl SlabEntryPacked {
     }
 
     #[inline]
-    pub const fn inp_fee_nanos(&self) -> i32 {
-        i32::from_le_bytes(self.inp_fee_nanos)
+    pub const fn inp_fee_nanos(&self) -> FeeNanos {
+        FeeNanos(i32::from_le_bytes(self.inp_fee_nanos))
     }
 
     #[inline]
-    pub const fn out_fee_nanos(&self) -> i32 {
-        i32::from_le_bytes(self.out_fee_nanos)
+    pub const fn out_fee_nanos(&self) -> FeeNanos {
+        FeeNanos(i32::from_le_bytes(self.out_fee_nanos))
     }
 }
 
@@ -57,13 +119,13 @@ impl SlabEntryPacked {
     }
 
     #[inline]
-    pub const fn set_inp_fee_nanos(&mut self, inp_fee_nanos: i32) {
-        self.inp_fee_nanos = inp_fee_nanos.to_le_bytes();
+    pub const fn set_inp_fee_nanos(&mut self, inp_fee_nanos: FeeNanos) {
+        self.inp_fee_nanos = inp_fee_nanos.get().to_le_bytes();
     }
 
     #[inline]
-    pub const fn set_out_fee_nanos(&mut self, out_fee_nanos: i32) {
-        self.out_fee_nanos = out_fee_nanos.to_le_bytes();
+    pub const fn set_out_fee_nanos(&mut self, out_fee_nanos: FeeNanos) {
+        self.out_fee_nanos = out_fee_nanos.get().to_le_bytes();
     }
 }
 

--- a/pricing/flatslab/program/src/err.rs
+++ b/pricing/flatslab/program/src/err.rs
@@ -58,6 +58,7 @@ macro_rules! seqerr {
 }
 
 seqerr!(
+    CantRemoveLpMint,
     MintNotFound(_),
     MissingAdminSignature,
     Pricing(_),

--- a/pricing/flatslab/program/src/err.rs
+++ b/pricing/flatslab/program/src/err.rs
@@ -59,6 +59,7 @@ macro_rules! seqerr {
 
 seqerr!(
     CantRemoveLpMint,
+    FeeNanosOutOfRange(_),
     MintNotFound(_),
     MissingAdminSignature,
     Pricing(_),

--- a/pricing/flatslab/program/src/lib.rs
+++ b/pricing/flatslab/program/src/lib.rs
@@ -2,13 +2,16 @@ use inf1_pp_core::instructions::{
     price::{exact_in::PRICE_EXACT_IN_IX_DISCM, exact_out::PRICE_EXACT_OUT_IX_DISCM},
     IxArgs,
 };
-use inf1_pp_flatslab_core::instructions::{
-    admin::{
-        remove_lst::REMOVE_LST_IX_DISCM,
-        set_admin::SET_ADMIN_IX_DISCM,
-        set_lst_fee::{SetLstFeeIxArgs, SET_LST_FEE_IX_DISCM},
+use inf1_pp_flatslab_core::{
+    errs::FlatSlabProgramErr,
+    instructions::{
+        admin::{
+            remove_lst::REMOVE_LST_IX_DISCM,
+            set_admin::SET_ADMIN_IX_DISCM,
+            set_lst_fee::{SetLstFeeIxArgs, SET_LST_FEE_IX_DISCM},
+        },
+        init::INIT_IX_DISCM,
     },
-    init::INIT_IX_DISCM,
 };
 use jiminy_entrypoint::{
     program_entrypoint,
@@ -91,7 +94,8 @@ fn process_ix(
         (&SET_LST_FEE_IX_DISCM, data) => {
             let accs = set_lst_fee_accs_checked(accounts)?;
             let args =
-                SetLstFeeIxArgs::parse(data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?);
+                SetLstFeeIxArgs::parse(data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?)
+                    .map_err(|e| CustomProgErr(FlatSlabProgramErr::FeeNanosOutOfRange(e)))?;
             process_set_lst_fee(accounts, accs, args)
         }
         (&REMOVE_LST_IX_DISCM, _data) => {

--- a/pricing/flatslab/program/src/utils.rs
+++ b/pricing/flatslab/program/src/utils.rs
@@ -42,7 +42,7 @@ fn verify_pks_slice<'a, 'acc>(
 
 pub fn admin_ix_verify_pks_err(expected: &[u8; 32], slab: Slab) -> ProgramError {
     if *expected == SLAB_ID {
-        ProgramError::from(CustomProgErr(FlatSlabProgramErr::WrongSlabAcc))
+        CustomProgErr(FlatSlabProgramErr::WrongSlabAcc).into()
     } else if expected == slab.admin() {
         CustomProgErr(FlatSlabProgramErr::MissingAdminSignature).into()
     } else {

--- a/pricing/flatslab/program/tests/common/props.rs
+++ b/pricing/flatslab/program/tests/common/props.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use inf1_pp_core::pair::Pair;
 use inf1_pp_flatslab_core::{
-    accounts::Slab,
+    accounts::{Slab, SlabMut},
     keys::{LP_MINT_ID, SLAB_ID},
     pricing::FlatSlabSwapPricing,
     typedefs::{SlabEntryPacked, SlabEntryPackedList},
@@ -14,10 +14,18 @@ use proptest::{collection::vec, prelude::*};
 pub const MAX_MINTS: usize = 10;
 
 const SLAB_HEADER_SIZE: usize = 32;
-const EXPECTED_ENTRY_SIZE: usize = 40;
 
-pub fn clean_valid_slab(rand_data: Vec<u8>) -> Vec<u8> {
-    let slab = Slab::of_acc_data(&rand_data).unwrap();
+pub fn clean_valid_slab(mut rand_data: Vec<u8>) -> Vec<u8> {
+    let mut slab = SlabMut::of_acc_data(&mut rand_data).unwrap();
+
+    // LP_MINT_ID always on slab invariant
+    let entries = slab.as_mut().1 .0;
+    if !entries.iter().any(|e| *e.mint() == LP_MINT_ID) {
+        *entries[0].mint_mut() = LP_MINT_ID;
+    }
+
+    let slab = slab.as_slab();
+
     // can probably use itertools dedup to avoid a new vec here
     let mut entries = Vec::from(slab.entries().0);
     entries.sort_unstable_by_key(|e| *e.mint());
@@ -29,19 +37,26 @@ pub fn clean_valid_slab(rand_data: Vec<u8>) -> Vec<u8> {
         .collect()
 }
 
+/// `mints_range` does NOT include LP_MINT; a LP mint entry will be automatically generated
 pub fn slab_data(mints_range: RangeInclusive<usize>) -> impl Strategy<Value = Vec<u8>> {
     mints_range
-        .prop_flat_map(|n| vec(any::<u8>(), Slab::account_size(n)))
+        .prop_flat_map(|n| vec(any::<u8>(), Slab::account_size(n + 1))) // +1 for LP_MINT
         .prop_map(clean_valid_slab)
 }
 
 pub fn slab_for_swap(
     max_mints: usize,
 ) -> impl Strategy<Value = (Vec<u8>, Pair<[u8; 32]>, FlatSlabSwapPricing)> {
-    slab_data(2usize..=max_mints) // need at least 2 elems for swap
+    slab_data(2usize..=max_mints) // need at least 2 mints for swap
         .prop_flat_map(|b| {
-            let len = Slab::of_acc_data(&b).unwrap().entries().0.len();
-            (Just(b), 0..len, 0..len)
+            let entries = Slab::of_acc_data(&b).unwrap().entries().0;
+            let len = entries.len();
+            let lp_idx = entries
+                .iter()
+                .position(|e| *e.mint() == LP_MINT_ID)
+                .unwrap();
+            let non_lp_idxs = (0..len).prop_filter("Must not be LP mint", move |i| *i != lp_idx);
+            (Just(b), non_lp_idxs.clone(), non_lp_idxs)
         })
         .prop_map(|(b, i, o)| {
             let slab = Slab::of_acc_data(&b).unwrap();
@@ -65,20 +80,13 @@ pub fn slab_for_swap(
 pub fn slab_for_liq(
     max_mints: usize,
 ) -> impl Strategy<Value = (Vec<u8>, [u8; 32], SlabEntryPacked, SlabEntryPacked)> {
-    slab_for_swap(max_mints)
-        .prop_flat_map(|tup| (Just(tup), any::<[u8; EXPECTED_ENTRY_SIZE]>()))
-        .prop_map(|((mut slab_data, Pair { inp, .. }, _), mut lp_entry)| {
-            lp_entry[..32].copy_from_slice(&LP_MINT_ID);
-            slab_data.extend(lp_entry);
-
-            let slab_data = clean_valid_slab(slab_data);
-            let entries = Slab::of_acc_data(&slab_data).unwrap().entries();
-            // just use randomly generated `inp` mint as the non LP mint
-            let [lp_entry, other_entry] =
-                [LP_MINT_ID, inp].map(|mint| *entries.find_by_mint(&mint).unwrap());
-
-            (slab_data, inp, lp_entry, other_entry)
-        })
+    slab_for_swap(max_mints).prop_map(|(slab_data, Pair { inp, .. }, _)| {
+        let entries = Slab::of_acc_data(&slab_data).unwrap().entries();
+        // just use randomly generated `inp` mint as the non LP mint
+        let [lp_entry, other_entry] =
+            [LP_MINT_ID, inp].map(|mint| *entries.find_by_mint(&mint).unwrap());
+        (slab_data, inp, lp_entry, other_entry)
+    })
 }
 
 pub fn non_slab_pks() -> impl Strategy<Value = [u8; 32]> {

--- a/pricing/flatslab/program/tests/tests/admin/mod.rs
+++ b/pricing/flatslab/program/tests/tests/admin/mod.rs
@@ -1,4 +1,8 @@
-use inf1_pp_flatslab_core::{accounts::Slab, keys::LP_MINT_ID, typedefs::SlabEntryPacked};
+use inf1_pp_flatslab_core::{
+    accounts::Slab,
+    keys::LP_MINT_ID,
+    typedefs::{FeeNanos, SlabEntryPacked},
+};
 use solana_pubkey::Pubkey;
 
 mod remove_lst;
@@ -16,6 +20,12 @@ pub fn assert_valid_slab(slab_acc_data: &[u8]) {
     }
     // assert LP mint always on slab invariant
     assert!(slab.entries().0.iter().any(|e| *e.mint() == LP_MINT_ID));
+    // assert FeeNanos range invariant
+    assert!(slab.entries().0.iter().all(|e| {
+        let i = e.inp_fee_nanos().get();
+        let o = e.out_fee_nanos().get();
+        i >= *FeeNanos::MIN && i <= *FeeNanos::MAX && o >= *FeeNanos::MIN && o <= *FeeNanos::MAX
+    }))
 }
 
 pub fn assert_slab_entry_on_slab(slab_acc_data: &[u8], expected: &SlabEntryPacked) {

--- a/pricing/flatslab/program/tests/tests/admin/mod.rs
+++ b/pricing/flatslab/program/tests/tests/admin/mod.rs
@@ -1,4 +1,4 @@
-use inf1_pp_flatslab_core::{accounts::Slab, typedefs::SlabEntryPacked};
+use inf1_pp_flatslab_core::{accounts::Slab, keys::LP_MINT_ID, typedefs::SlabEntryPacked};
 use solana_pubkey::Pubkey;
 
 mod remove_lst;
@@ -14,6 +14,8 @@ pub fn assert_valid_slab(slab_acc_data: &[u8]) {
             panic!("duplicate {}", Pubkey::new_from_array(*w[0].mint()));
         }
     }
+    // assert LP mint always on slab invariant
+    assert!(slab.entries().0.iter().any(|e| *e.mint() == LP_MINT_ID));
 }
 
 pub fn assert_slab_entry_on_slab(slab_acc_data: &[u8], expected: &SlabEntryPacked) {

--- a/pricing/flatslab/program/tests/tests/admin/remove_lst.rs
+++ b/pricing/flatslab/program/tests/tests/admin/remove_lst.rs
@@ -6,7 +6,7 @@ use inf1_pp_flatslab_core::{
         NewRemoveLstIxAccsBuilder, RemoveLstIxAccs, RemoveLstIxData, RemoveLstIxKeysOwned,
         REMOVE_LST_IX_ACCS_IDX_ADMIN, REMOVE_LST_IX_IS_SIGNER, REMOVE_LST_IX_IS_WRITER,
     },
-    keys::SLAB_ID,
+    keys::{LP_MINT_ID, SLAB_ID},
     ID,
 };
 use mollusk_svm::result::{Check, InstructionResult, ProgramResult};
@@ -136,6 +136,27 @@ proptest! {
         let ix = remove_lst_ix(&keys);
         let accs = remove_lst_ix_accounts(&keys, slab.clone());
         remove_lst_success_test(&mint, &slab, &ix, accs);
+    }
+}
+
+proptest! {
+    #[test]
+    fn remove_lst_fails_if_lp_mint(
+        slab in slab_data(0..=MAX_MINTS),
+        rrt in rand_unknown_pk(),
+    ) {
+        silence_mollusk_logs();
+
+        let admin = *Slab::of_acc_data(&slab).unwrap().admin();
+        let keys = NewRemoveLstIxAccsBuilder::start()
+            .with_admin(admin)
+            .with_mint(LP_MINT_ID)
+            .with_refund_rent_to(rrt)
+            .with_slab(SLAB_ID)
+            .build();
+        let ix = remove_lst_ix(&keys);
+        let accs = remove_lst_ix_accounts(&keys, slab.clone());
+        should_fail_with_flatslab_prog_err(&ix, &accs.0, FlatSlabProgramErr::CantRemoveLpMint);
     }
 }
 

--- a/pricing/flatslab/program/tests/tests/admin/set_lst_fee.rs
+++ b/pricing/flatslab/program/tests/tests/admin/set_lst_fee.rs
@@ -7,7 +7,7 @@ use inf1_pp_flatslab_core::{
         SET_LST_FEE_IX_IS_WRITER,
     },
     keys::SLAB_ID,
-    typedefs::{FeeNanos, SlabEntryPacked},
+    typedefs::{FeeNanos, FeeNanosOutOfRangeErr, SlabEntryPacked},
     ID,
 };
 use inf1_pp_flatslab_program::SYS_PROG_ID;
@@ -187,6 +187,55 @@ proptest! {
         let ix = set_lst_fee_ix(&keys, SetLstFeeIxArgs { inp_fee_nanos, out_fee_nanos });
         let accs = set_lst_fee_ix_accounts(&keys, slab);
         should_fail_with_flatslab_prog_err(&ix, &accs.0, FlatSlabProgramErr::MissingAdminSignature);
+    }
+}
+
+proptest! {
+    #[test]
+    fn set_lst_fails_with_invalid_fee_nanos(
+        slab in slab_data(0..=MAX_MINTS),
+        payer in rand_unknown_pk(),
+        mint in rand_unknown_pk(),
+        ok_fee_nanos in *FeeNanos::MIN..=*FeeNanos::MAX,
+        err_fee_nanos in (i32::MIN..=*FeeNanos::MIN - 1).prop_union(*FeeNanos::MAX + 1..=i32::MAX),
+        err_fee_nanos_2 in (i32::MIN..=*FeeNanos::MIN - 1).prop_union(*FeeNanos::MAX + 1..=i32::MAX),
+    ) {
+        silence_mollusk_logs();
+
+        let admin = *Slab::of_acc_data(&slab).unwrap().admin();
+        let keys = NewSetLstFeeIxAccsBuilder::start()
+            .with_admin(admin)
+            .with_mint(mint)
+            .with_payer(payer)
+            .with_system_program(SYS_PROG_ID)
+            .with_slab(SLAB_ID)
+            .build();
+        let accs = set_lst_fee_ix_accounts(&keys, slab.clone());
+
+        for (i, o) in [
+            (ok_fee_nanos, err_fee_nanos),
+            (err_fee_nanos, ok_fee_nanos),
+            (err_fee_nanos, err_fee_nanos_2),
+        ] {
+            // create ix with dummy args then replace with actual bad data
+            let mut ix = set_lst_fee_ix(
+                &keys,
+                SetLstFeeIxArgs {
+                    inp_fee_nanos: FeeNanos::MIN,
+                    out_fee_nanos: FeeNanos::MIN
+                }
+            );
+            ix.data[1..5].copy_from_slice(&i.to_le_bytes());
+            ix.data[5..].copy_from_slice(&o.to_le_bytes());
+
+            should_fail_with_flatslab_prog_err(
+                &ix,
+                &accs.0,
+                // only checking error code here, so inner data
+                // of FeeNanosOutOfRangeErr dont matter here
+                FlatSlabProgramErr::FeeNanosOutOfRange(FeeNanosOutOfRangeErr { actual: 1_000_000_001 }),
+            );
+        }
     }
 }
 

--- a/pricing/flatslab/program/tests/tests/admin/set_lst_fee.rs
+++ b/pricing/flatslab/program/tests/tests/admin/set_lst_fee.rs
@@ -7,7 +7,7 @@ use inf1_pp_flatslab_core::{
         SET_LST_FEE_IX_IS_WRITER,
     },
     keys::SLAB_ID,
-    typedefs::SlabEntryPacked,
+    typedefs::{FeeNanos, SlabEntryPacked},
     ID,
 };
 use inf1_pp_flatslab_program::SYS_PROG_ID;
@@ -82,10 +82,13 @@ proptest! {
         slab in slab_data(0..=MAX_MINTS),
         payer in rand_unknown_pk(),
         mint in rand_unknown_pk(),
-        inp_fee_nanos: i32,
-        out_fee_nanos: i32,
+        inp_fee_nanos in *FeeNanos::MIN..=*FeeNanos::MAX,
+        out_fee_nanos in *FeeNanos::MIN..=*FeeNanos::MAX,
     ) {
         silence_mollusk_logs();
+
+        let [inp_fee_nanos, out_fee_nanos] = [inp_fee_nanos, out_fee_nanos]
+            .map(|f| FeeNanos::new(f).unwrap());
 
         let admin = *Slab::of_acc_data(&slab).unwrap().admin();
         let keys = NewSetLstFeeIxAccsBuilder::start()
@@ -131,10 +134,13 @@ proptest! {
         slab in slab_data(0..=MAX_MINTS),
         payer in rand_unknown_pk(),
         mint in rand_unknown_pk(),
-        inp_fee_nanos: i32,
-        out_fee_nanos: i32,
+        inp_fee_nanos in *FeeNanos::MIN..=*FeeNanos::MAX,
+        out_fee_nanos in *FeeNanos::MIN..=*FeeNanos::MAX,
     ) {
         silence_mollusk_logs();
+
+        let [inp_fee_nanos, out_fee_nanos] = [inp_fee_nanos, out_fee_nanos]
+            .map(|f| FeeNanos::new(f).unwrap());
 
         let admin = *Slab::of_acc_data(&slab).unwrap().admin();
         let keys = NewSetLstFeeIxAccsBuilder::start()
@@ -158,8 +164,8 @@ proptest! {
         wrong_admin: [u8; 32],
         payer in rand_unknown_pk(),
         mint in rand_unknown_pk(),
-        inp_fee_nanos: i32,
-        out_fee_nanos: i32,
+        inp_fee_nanos in *FeeNanos::MIN..=*FeeNanos::MAX,
+        out_fee_nanos in *FeeNanos::MIN..=*FeeNanos::MAX,
     ) {
         let admin = *Slab::of_acc_data(&slab).unwrap().admin();
         if wrong_admin == admin {
@@ -167,6 +173,9 @@ proptest! {
         }
 
         silence_mollusk_logs();
+
+        let [inp_fee_nanos, out_fee_nanos] = [inp_fee_nanos, out_fee_nanos]
+            .map(|f| FeeNanos::new(f).unwrap());
 
         let keys = NewSetLstFeeIxAccsBuilder::start()
             .with_admin(wrong_admin)
@@ -202,8 +211,8 @@ fn set_lst_fee_cu_upper_limit() {
     rng.fill_bytes(&mut bytes);
     let slab_data = clean_valid_slab(bytes);
     let args = SetLstFeeIxArgs {
-        inp_fee_nanos: 1_000_000_000,
-        out_fee_nanos: 1_000_000_000,
+        inp_fee_nanos: FeeNanos::MAX,
+        out_fee_nanos: FeeNanos::MAX,
     };
     // worst-case: adding entry at start of array means
     // having to shift entire array right


### PR DESCRIPTION
Merge #66 first

Introduce clamped i32 NewType `FeeNanos` to ensure vals within our defined range