### PR TITLE
chore: refactor to reusable `lst_sync_sol_val_unchecked`

### DIFF
--- a/controller/program/src/instructions/sync_sol_value.rs
+++ b/controller/program/src/instructions/sync_sol_value.rs
@@ -1,3 +1,4 @@
+use inf1_core::instructions::sync_sol_value::SyncSolValueIxAccs;
 use inf1_ctl_jiminy::{
     accounts::{lst_state_list::LstStatePackedList, pool_state::PoolState},
     err::Inf1CtlErr,
@@ -57,5 +58,14 @@ pub fn process_sync_sol_value(
 
     let calc = ix_prefix.0.len() + 1..accounts.as_slice().len();
 
-    lst_sync_sol_val_unchecked(accounts, cpi, ix_prefix, lst_idx, *calc_prog, calc)
+    lst_sync_sol_val_unchecked(
+        accounts,
+        cpi,
+        SyncSolValueIxAccs {
+            ix_prefix,
+            calc_prog: *calc_prog,
+            calc,
+        },
+        lst_idx,
+    )
 }


### PR DESCRIPTION
## Description

This PR refactors the common procedure which involves the following into a common function that can be reused wherever we need to sync the sol value of a given lst, such as `sync_sol_value`, `swap_exact_in`, etc

- Read LST reserve account balance
- CPI `LstToSol` instruction in SVC program
- Updating the `LstStateList` and the `PoolState` account data with the new SOL value