### PR TITLE
update jiminy vers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,7 +1962,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 [[package]]
 name = "jiminy-account"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "jiminy-program-error",
 ]
@@ -1970,7 +1970,7 @@ dependencies = [
 [[package]]
 name = "jiminy-cpi"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "jiminy-account",
  "jiminy-pda",
@@ -1981,7 +1981,7 @@ dependencies = [
 [[package]]
 name = "jiminy-entrypoint"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "jiminy-account",
  "jiminy-syscall",
@@ -1990,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "jiminy-log"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#a4f1381ed9291404d32c889be019a1831d0583cc"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "jiminy-syscall",
 ]
@@ -1998,7 +1998,7 @@ dependencies = [
 [[package]]
 name = "jiminy-pda"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "jiminy-syscall",
 ]
@@ -2006,12 +2006,12 @@ dependencies = [
 [[package]]
 name = "jiminy-program-error"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 
 [[package]]
 name = "jiminy-return-data"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "jiminy-syscall",
 ]
@@ -2019,12 +2019,12 @@ dependencies = [
 [[package]]
 name = "jiminy-syscall"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 
 [[package]]
 name = "jiminy-sysvar"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "const-crypto",
  "jiminy-program-error",
@@ -2034,7 +2034,7 @@ dependencies = [
 [[package]]
 name = "jiminy-sysvar-rent"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#7b3b884eb7144d626e4f6e4d3881d9ea44bab150"
+source = "git+https://github.com/igneous-labs/jiminy.git?branch=master#92fc4e4236a47e68d5ed34a1b1b2a15220424c5f"
 dependencies = [
  "const-crypto",
  "jiminy-sysvar",
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "sanctum-system-core"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/sanctum-system-sdk.git?branch=master#80620c983e7944733094e91dd2bcaa4ebfef1580"
+source = "git+https://github.com/igneous-labs/sanctum-system-sdk.git?branch=master#5aeaa1464566a025247a4f8c8b502ab311f662f5"
 dependencies = [
  "generic-array-struct",
 ]
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "sanctum-system-jiminy"
 version = "0.1.0"
-source = "git+https://github.com/igneous-labs/sanctum-system-sdk.git?branch=master#80620c983e7944733094e91dd2bcaa4ebfef1580"
+source = "git+https://github.com/igneous-labs/sanctum-system-sdk.git?branch=master#5aeaa1464566a025247a4f8c8b502ab311f662f5"
 dependencies = [
  "jiminy-cpi",
  "sanctum-system-core",

--- a/controller/program/src/instructions/sync_sol_value.rs
+++ b/controller/program/src/instructions/sync_sol_value.rs
@@ -7,32 +7,35 @@ use inf1_ctl_jiminy::{
     pda_onchain::create_raw_pool_reserves_addr,
     program_err::Inf1CtlCustomProgErr,
 };
-use jiminy_cpi::program_error::{ProgramError, NOT_ENOUGH_ACCOUNT_KEYS};
+use jiminy_cpi::{
+    account::{Abr, AccountHandle},
+    program_error::{ProgramError, NOT_ENOUGH_ACCOUNT_KEYS},
+};
 
 use crate::{
     svc::lst_sync_sol_val_unchecked,
     verify::{verify_not_rebalancing_and_not_disabled, verify_pks},
-    Accounts, Cpi,
+    Cpi,
 };
 
 #[inline]
 pub fn process_sync_sol_value(
-    accounts: &mut Accounts<'_>,
+    abr: &mut Abr,
+    accounts: &[AccountHandle<'_>],
     lst_idx: usize,
     cpi: &mut Cpi,
 ) -> Result<(), ProgramError> {
     let (ix_prefix, suf) = accounts
-        .as_slice()
         .split_first_chunk()
         .ok_or(NOT_ENOUGH_ACCOUNT_KEYS)?;
     let ix_prefix = SyncSolValueIxPreAccs(*ix_prefix);
-    let list = LstStatePackedList::of_acc_data(accounts.get(*ix_prefix.lst_state_list()).data())
+    let list = LstStatePackedList::of_acc_data(abr.get(*ix_prefix.lst_state_list()).data())
         .ok_or(Inf1CtlCustomProgErr(Inf1CtlErr::InvalidLstStateListData))?;
     let lst_state = list
         .0
         .get(lst_idx)
         .ok_or(Inf1CtlCustomProgErr(Inf1CtlErr::InvalidLstIndex))?;
-    let lst_mint_acc = accounts.get(*ix_prefix.lst_mint());
+    let lst_mint_acc = abr.get(*ix_prefix.lst_mint());
     let token_prog = lst_mint_acc.owner();
     // safety: account data is 8-byte aligned
     let lst_state = unsafe { lst_state.as_lst_state() };
@@ -46,20 +49,18 @@ pub fn process_sync_sol_value(
         .with_pool_state(&POOL_STATE_ID)
         .with_pool_reserves(&expected_reserves)
         .build();
-    verify_pks(accounts, &ix_prefix.0, &expected_pks.0)?;
+    verify_pks(abr, &ix_prefix.0, &expected_pks.0)?;
 
-    let calc_prog = suf.first().ok_or(NOT_ENOUGH_ACCOUNT_KEYS)?;
-    verify_pks(accounts, &[*calc_prog], &[&lst_state.sol_value_calculator])?;
+    let (calc_prog, calc) = suf.split_first().ok_or(NOT_ENOUGH_ACCOUNT_KEYS)?;
+    verify_pks(abr, &[*calc_prog], &[&lst_state.sol_value_calculator])?;
 
     // safety: account data is 8-byte aligned
-    let pool = unsafe { PoolState::of_acc_data(accounts.get(*ix_prefix.pool_state()).data()) }
+    let pool = unsafe { PoolState::of_acc_data(abr.get(*ix_prefix.pool_state()).data()) }
         .ok_or(Inf1CtlCustomProgErr(Inf1CtlErr::InvalidPoolStateData))?;
     verify_not_rebalancing_and_not_disabled(pool)?;
 
-    let calc = ix_prefix.0.len() + 1..accounts.as_slice().len();
-
     lst_sync_sol_val_unchecked(
-        accounts,
+        abr,
         cpi,
         SyncSolValueIxAccs {
             ix_prefix,

--- a/controller/program/src/lib.rs
+++ b/controller/program/src/lib.rs
@@ -6,7 +6,10 @@ use inf1_ctl_jiminy::instructions::{
     set_sol_value_calculator::{SetSolValueCalculatorIxData, SET_SOL_VALUE_CALC_IX_DISCM},
     sync_sol_value::{SyncSolValueIxData, SYNC_SOL_VALUE_IX_DISCM},
 };
-use jiminy_cpi::program_error::INVALID_INSTRUCTION_DATA;
+use jiminy_cpi::{
+    account::{Abr, AccountHandle},
+    program_error::INVALID_INSTRUCTION_DATA,
+};
 use jiminy_entrypoint::{
     allocator::Allogator, default_panic_handler, program_entrypoint, program_error::ProgramError,
 };
@@ -22,8 +25,6 @@ mod svc;
 mod verify;
 
 const MAX_ACCS: usize = 64;
-
-type Accounts<'account> = jiminy_entrypoint::account::Accounts<'account, MAX_ACCS>;
 
 /// Ensure no pricing program or sol value calculator programs require
 /// more than this number of accounts for CPI
@@ -49,7 +50,8 @@ program_entrypoint!(process_ix, MAX_ACCS);
 
 #[inline]
 fn process_ix(
-    accounts: &mut Accounts,
+    abr: &mut Abr,
+    accounts: &[AccountHandle<'_>],
     data: &[u8],
     _prog_id: &[u8; 32],
 ) -> Result<(), ProgramError> {
@@ -66,14 +68,14 @@ fn process_ix(
             let lst_idx = SyncSolValueIxData::parse_no_discm(
                 data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?,
             ) as usize;
-            process_sync_sol_value(accounts, lst_idx, cpi)
+            process_sync_sol_value(abr, accounts, lst_idx, cpi)
         }
         (&SET_SOL_VALUE_CALC_IX_DISCM, data) => {
             sol_log("SetSolValueCalculator");
             let lst_idx = SetSolValueCalculatorIxData::parse_no_discm(
                 data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?,
             ) as usize;
-            process_set_sol_value_calculator(accounts, lst_idx, cpi)
+            process_set_sol_value_calculator(abr, accounts, lst_idx, cpi)
         }
         _ => Err(INVALID_INSTRUCTION_DATA.into()),
     }

--- a/controller/program/src/svc.rs
+++ b/controller/program/src/svc.rs
@@ -1,5 +1,3 @@
-use core::ops::Range;
-
 use inf1_core::{instructions::sync_sol_value::SyncSolValueIxAccs, sync::SyncSolVal};
 use inf1_ctl_jiminy::{
     accounts::{lst_state_list::LstStatePackedListMut, pool_state::PoolState},
@@ -7,28 +5,31 @@ use inf1_ctl_jiminy::{
     err::Inf1CtlErr,
     program_err::Inf1CtlCustomProgErr,
 };
-use inf1_svc_jiminy::cpi::cpi_lst_to_sol;
-// rename to disambiguate type name
-/// Accounts builder for SolToLst and LstToSol
-pub use inf1_svc_jiminy::instructions::NewIxPreAccsBuilder as NewSvcIxPreAccsBuilder;
+use inf1_svc_jiminy::{
+    cpi::{cpi_lst_to_sol, IxAccountHandles as SvcIxAccountHandles},
+    instructions::NewIxPreAccsBuilder as NewSvcIxPreAccsBuilder,
+};
 use jiminy_cpi::{
-    account::AccountHandle,
+    account::{Abr, AccountHandle},
     program_error::{ProgramError, INVALID_ACCOUNT_DATA},
 };
 use sanctum_spl_token_jiminy::sanctum_spl_token_core::state::account::{
     RawTokenAccount, TokenAccount,
 };
 
-use crate::{Accounts, Cpi};
+use crate::Cpi;
 
-pub type SyncSolValIxAccounts<'acc> =
-    SyncSolValueIxAccs<AccountHandle<'acc>, SyncSolValueIxPreAccountHandles<'acc>, Range<usize>>;
+pub type SyncSolValIxAccounts<'a, 'acc> = SyncSolValueIxAccs<
+    AccountHandle<'acc>,
+    SyncSolValueIxPreAccountHandles<'acc>,
+    &'a [AccountHandle<'acc>],
+>;
 
 #[inline]
 pub fn lst_sync_sol_val_unchecked<'acc>(
-    accounts: &mut Accounts<'acc>,
+    abr: &mut Abr,
     cpi: &mut Cpi,
-    sync_sol_val_accs: SyncSolValIxAccounts<'acc>,
+    sync_sol_val_accs: SyncSolValIxAccounts<'_, 'acc>,
     lst_index: usize,
 ) -> Result<(), ProgramError> {
     let SyncSolValueIxAccs {
@@ -43,25 +44,27 @@ pub fn lst_sync_sol_val_unchecked<'acc>(
     let lst_mint = *ix_prefix.lst_mint();
 
     // Sync sol value for input LST
-    let lst_balance = RawTokenAccount::of_acc_data(accounts.get(pool_reserves).data())
+    let lst_balance = RawTokenAccount::of_acc_data(abr.get(pool_reserves).data())
         .and_then(TokenAccount::try_from_raw)
         .map(|a| a.amount())
         .ok_or(INVALID_ACCOUNT_DATA)?;
 
     let cpi_retval = cpi_lst_to_sol(
         cpi,
-        accounts,
+        abr,
         calc_prog,
         lst_balance,
-        NewSvcIxPreAccsBuilder::start()
-            .with_lst_mint(lst_mint)
-            .build(),
-        calc,
+        SvcIxAccountHandles::new(
+            NewSvcIxPreAccsBuilder::start()
+                .with_lst_mint(lst_mint)
+                .build(),
+            calc,
+        ),
     )?;
 
     let lst_new = *cpi_retval.start();
 
-    let list = LstStatePackedListMut::of_acc_data(accounts.get_mut(lst_state_list).data_mut())
+    let list = LstStatePackedListMut::of_acc_data(abr.get_mut(lst_state_list).data_mut())
         .ok_or(Inf1CtlCustomProgErr(Inf1CtlErr::InvalidLstStateListData))?;
     let lst_state = list
         .0
@@ -73,7 +76,7 @@ pub fn lst_sync_sol_val_unchecked<'acc>(
     lst_state.sol_value = lst_new;
 
     // safety: account data is 8-byte aligned
-    let pool = unsafe { PoolState::of_acc_data_mut(accounts.get_mut(pool_state).data_mut()) }
+    let pool = unsafe { PoolState::of_acc_data_mut(abr.get_mut(pool_state).data_mut()) }
         .ok_or(Inf1CtlCustomProgErr(Inf1CtlErr::InvalidPoolStateData))?;
     pool.total_sol_value = SyncSolVal {
         pool_total: pool.total_sol_value,

--- a/controller/program/src/verify.rs
+++ b/controller/program/src/verify.rs
@@ -3,40 +3,38 @@ use inf1_ctl_jiminy::{
     typedefs::u8bool::U8Bool,
 };
 use jiminy_cpi::{
-    account::{Account, AccountHandle},
+    account::{Abr, Account, AccountHandle},
     program_error::{BuiltInProgramError, ProgramError, INVALID_ARGUMENT},
 };
 
-use crate::Accounts;
-
 #[inline]
-pub fn verify_pks<'a, 'acc, const LEN: usize>(
-    accounts: &Accounts<'acc>,
-    handles: &'a [AccountHandle<'acc>; LEN],
-    expected: &'a [&[u8; 32]; LEN],
+pub fn verify_pks<'acc, const LEN: usize>(
+    abr: &Abr,
+    handles: &[AccountHandle<'acc>; LEN],
+    expected: &[&[u8; 32]; LEN],
 ) -> Result<(), ProgramError> {
-    verify_pks_pure(accounts, handles, expected).map_err(wrong_acc_logmapper(accounts))
+    verify_pks_pure(abr, handles, expected).map_err(wrong_acc_logmapper(abr))
 }
 
 #[inline]
 fn verify_pks_pure<'a, 'acc, const LEN: usize>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>; LEN],
     expected: &'a [&[u8; 32]; LEN],
 ) -> Result<(), (&'a AccountHandle<'acc>, &'a [u8; 32])> {
-    verify_pks_slice(accounts, handles, expected)
+    verify_pks_slice(abr, handles, expected)
 }
 
 /// [`verify_pks`] delegates to this to minimize monomorphization,
 /// while its const generic LEN ensures both slices are of the same len  
 #[inline]
 fn verify_pks_slice<'a, 'acc>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>],
     expected: &'a [&[u8; 32]],
 ) -> Result<(), (&'a AccountHandle<'acc>, &'a [u8; 32])> {
     handles.iter().zip(expected).try_for_each(|(h, e)| {
-        if accounts.get(*h).key() == *e {
+        if abr.get(*h).key() == *e {
             Ok(())
         } else {
             Err((h, *e))
@@ -46,14 +44,14 @@ fn verify_pks_slice<'a, 'acc>(
 
 #[inline]
 fn wrong_acc_logmapper<'a, 'acc>(
-    accounts: &'a Accounts<'acc>,
+    abr: &'a Abr,
 ) -> impl FnOnce((&AccountHandle<'acc>, &[u8; 32])) -> ProgramError + 'a {
     |(actual, expected)| {
         // dont use format macro to save CUs and binsize
         jiminy_log::sol_log("Wrong account. Expected:");
         jiminy_log::sol_log_pubkey(expected);
         jiminy_log::sol_log("Got:");
-        jiminy_log::sol_log_pubkey(accounts.get(*actual).key());
+        jiminy_log::sol_log_pubkey(abr.get(*actual).key());
         // current onchain prog just returns this err, so follow behaviour
         INVALID_ARGUMENT.into()
     }
@@ -72,16 +70,16 @@ pub fn verify_not_rebalancing_and_not_disabled(pool: &PoolState) -> Result<(), P
 
 #[inline]
 pub fn verify_signers<'a, 'acc, const LEN: usize>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>; LEN],
     expected_is_signer: &'a [bool; LEN],
 ) -> Result<(), &'a AccountHandle<'acc>> {
-    verify_signers_slice(accounts, handles, expected_is_signer)
+    verify_signers_slice(abr, handles, expected_is_signer)
 }
 
 /// [`verify_signers`] delegates to this to minimize monomorphization
 fn verify_signers_slice<'a, 'acc>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>],
     expected_is_signer: &'a [bool],
 ) -> Result<(), &'a AccountHandle<'acc>> {
@@ -89,7 +87,7 @@ fn verify_signers_slice<'a, 'acc>(
         .iter()
         .zip(expected_is_signer)
         .try_for_each(|(h, should_be_signer)| {
-            if *should_be_signer && !accounts.get(*h).is_signer() {
+            if *should_be_signer && !abr.get(*h).is_signer() {
                 Err(h)
             } else {
                 Ok(())
@@ -97,12 +95,9 @@ fn verify_signers_slice<'a, 'acc>(
         })
 }
 
-pub fn log_and_return_acc_privilege_err(
-    accounts: &Accounts,
-    expected_signer: AccountHandle,
-) -> ProgramError {
+pub fn log_and_return_acc_privilege_err(abr: &Abr, expected_signer: AccountHandle) -> ProgramError {
     jiminy_log::sol_log("Signer privilege escalated for:");
-    jiminy_log::sol_log_pubkey(accounts.get(expected_signer).key());
+    jiminy_log::sol_log_pubkey(abr.get(expected_signer).key());
     BuiltInProgramError::MissingRequiredSignature.into()
 }
 

--- a/controller/program/tests/tests/set_sol_value_calculator.rs
+++ b/controller/program/tests/tests/set_sol_value_calculator.rs
@@ -199,7 +199,7 @@ fn set_sol_value_calculator_jupsol_fixture() {
         &accounts,
         &resulting_accounts,
         JUPSOL_MINT.as_array(),
-        &jupsol_fixtures_svc_suf().svc_program_id(),
+        jupsol_fixtures_svc_suf().svc_program_id(),
     );
 }
 
@@ -209,6 +209,7 @@ enum TestErrorType {
     PoolDisabled,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn set_sol_value_calculator_proptest(
     pool: PoolState,
     mut lsl: LstStateListData,

--- a/pricing/flatslab/program/src/instructions/admin/set_admin.rs
+++ b/pricing/flatslab/program/src/instructions/admin/set_admin.rs
@@ -6,13 +6,11 @@ use inf1_pp_flatslab_core::{
     keys::SLAB_ID,
 };
 use jiminy_cpi::{
-    account::AccountHandle,
+    account::{Abr, AccountHandle},
     program_error::{ProgramError, INVALID_ACCOUNT_DATA, NOT_ENOUGH_ACCOUNT_KEYS},
 };
 
-use crate::{
-    admin_ix_verify_pks_err, admin_ix_verify_signers_err, verify_pks, verify_signers, Accounts,
-};
+use crate::{admin_ix_verify_pks_err, admin_ix_verify_signers_err, verify_pks, verify_signers};
 
 pub type SetAdminIxAccHandles<'a> = SetAdminIxAccs<AccountHandle<'a>>;
 
@@ -25,35 +23,36 @@ fn expected_set_admin_ix_keys<'a>(slab: &'a Slab, new_admin: &'a [u8; 32]) -> Se
 }
 
 pub fn set_admin_accs_checked<'acc>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
+    accounts: &[AccountHandle<'acc>],
 ) -> Result<SetAdminIxAccHandles<'acc>, ProgramError> {
-    let Some(accs) = accounts.as_slice().first_chunk() else {
+    let Some(accs) = accounts.first_chunk() else {
         return Err(NOT_ENOUGH_ACCOUNT_KEYS.into());
     };
     let accs = SetAdminIxAccHandles::new(*accs);
 
-    let slab = Slab::of_acc_data(accounts.get(*accs.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
+    let slab = Slab::of_acc_data(abr.get(*accs.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
 
     verify_pks(
-        accounts,
+        abr,
         &accs.0,
-        &expected_set_admin_ix_keys(&slab, accounts.get(*accs.new_admin()).key()).0,
+        &expected_set_admin_ix_keys(&slab, abr.get(*accs.new_admin()).key()).0,
     )
     .map_err(|(_actual, expected)| admin_ix_verify_pks_err(expected, slab))?;
 
-    verify_signers(accounts, &accs.0, &SET_ADMIN_IX_IS_SIGNER.0)
-        .map_err(|expected_signer| admin_ix_verify_signers_err(accounts, *expected_signer, slab))?;
+    verify_signers(abr, &accs.0, &SET_ADMIN_IX_IS_SIGNER.0)
+        .map_err(|expected_signer| admin_ix_verify_signers_err(abr, *expected_signer, slab))?;
 
     Ok(accs)
 }
 
 pub fn process_set_admin<'acc>(
-    accounts: &mut Accounts<'acc>,
+    abr: &mut Abr,
     accs: SetAdminIxAccHandles<'acc>,
 ) -> Result<(), ProgramError> {
-    let new_admin_pk = *accounts.get(*accs.new_admin()).key();
-    let mut slab = SlabMut::of_acc_data(accounts.get_mut(*accs.slab()).data_mut())
-        .ok_or(INVALID_ACCOUNT_DATA)?;
+    let new_admin_pk = *abr.get(*accs.new_admin()).key();
+    let mut slab =
+        SlabMut::of_acc_data(abr.get_mut(*accs.slab()).data_mut()).ok_or(INVALID_ACCOUNT_DATA)?;
     let (admin, _) = slab.as_mut();
     *admin = new_admin_pk;
     Ok(())

--- a/pricing/flatslab/program/src/instructions/admin/set_lst_fee.rs
+++ b/pricing/flatslab/program/src/instructions/admin/set_lst_fee.rs
@@ -7,47 +7,48 @@ use inf1_pp_flatslab_core::{
     typedefs::{MintNotFoundErr, SlabEntryPacked},
 };
 use jiminy_cpi::{
-    account::AccountHandle,
+    account::{Abr, AccountHandle},
     program_error::{ProgramError, INVALID_ACCOUNT_DATA, NOT_ENOUGH_ACCOUNT_KEYS},
 };
 use sanctum_system_jiminy::sanctum_system_core::instructions::transfer::NewTransferIxAccsBuilder;
 
 use crate::{
     admin_ix_verify_pks_err, admin_ix_verify_signers_err, pay_for_rent_exempt_shortfall,
-    verify_pks, verify_signers, Accounts, Cpi, SYS_PROG_ID,
+    verify_pks, verify_signers, Cpi, SYS_PROG_ID,
 };
 
 pub type SetLstFeeIxAccHandles<'a> = SetLstFeeIxAccs<AccountHandle<'a>>;
 
 pub fn set_lst_fee_accs_checked<'acc>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
+    accounts: &[AccountHandle<'acc>],
 ) -> Result<SetLstFeeIxAccHandles<'acc>, ProgramError> {
-    let Some(accs) = accounts.as_slice().first_chunk() else {
+    let Some(accs) = accounts.first_chunk() else {
         return Err(NOT_ENOUGH_ACCOUNT_KEYS.into());
     };
     let accs = SetLstFeeIxAccHandles::new(*accs);
 
-    let slab = Slab::of_acc_data(accounts.get(*accs.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
+    let slab = Slab::of_acc_data(abr.get(*accs.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
 
     let expected_keys = NewSetLstFeeIxAccsBuilder::start()
         .with_slab(&SLAB_ID)
         .with_system_program(&SYS_PROG_ID)
         .with_admin(slab.admin())
-        .with_mint(accounts.get(*accs.mint()).key())
-        .with_payer(accounts.get(*accs.payer()).key())
+        .with_mint(abr.get(*accs.mint()).key())
+        .with_payer(abr.get(*accs.payer()).key())
         .build();
 
-    verify_pks(accounts, &accs.0, &expected_keys.0)
+    verify_pks(abr, &accs.0, &expected_keys.0)
         .map_err(|(_actual, expected)| admin_ix_verify_pks_err(expected, slab))?;
 
-    verify_signers(accounts, &accs.0, &SET_LST_FEE_IX_IS_SIGNER.0)
-        .map_err(|expected_signer| admin_ix_verify_signers_err(accounts, *expected_signer, slab))?;
+    verify_signers(abr, &accs.0, &SET_LST_FEE_IX_IS_SIGNER.0)
+        .map_err(|expected_signer| admin_ix_verify_signers_err(abr, *expected_signer, slab))?;
 
     Ok(accs)
 }
 
 pub fn process_set_lst_fee<'acc>(
-    accounts: &mut Accounts<'acc>,
+    abr: &mut Abr,
     accs: SetLstFeeIxAccHandles<'acc>,
     SetLstFeeIxArgs {
         inp_fee_nanos,
@@ -56,9 +57,9 @@ pub fn process_set_lst_fee<'acc>(
 ) -> Result<(), ProgramError> {
     let mut cpi = Cpi::new();
 
-    let mint = *accounts.get(*accs.mint()).key();
+    let mint = *abr.get(*accs.mint()).key();
 
-    let slab_acc = accounts.get_mut(*accs.slab());
+    let slab_acc = abr.get_mut(*accs.slab());
     let mut slab = SlabMut::of_acc_data(slab_acc.data_mut()).ok_or(INVALID_ACCOUNT_DATA)?;
     let (_, mut entries) = slab.as_mut();
 
@@ -79,7 +80,7 @@ pub fn process_set_lst_fee<'acc>(
             let new_acc_len = slab_acc.data_len();
 
             pay_for_rent_exempt_shortfall(
-                accounts,
+                abr,
                 &mut cpi,
                 NewTransferIxAccsBuilder::start()
                     .with_from(*accs.payer())
@@ -88,7 +89,7 @@ pub fn process_set_lst_fee<'acc>(
                 new_acc_len,
             )?;
 
-            let mut slab = SlabMut::of_acc_data(accounts.get_mut(*accs.slab()).data_mut())
+            let mut slab = SlabMut::of_acc_data(abr.get_mut(*accs.slab()).data_mut())
                 .ok_or(INVALID_ACCOUNT_DATA)?;
             let (_, entries) = slab.as_mut();
             let entry = &mut entries.0.get_mut(expected_i).ok_or(INVALID_ACCOUNT_DATA)?;

--- a/pricing/flatslab/program/src/instructions/init.rs
+++ b/pricing/flatslab/program/src/instructions/init.rs
@@ -7,6 +7,7 @@ use inf1_pp_flatslab_core::{
     typedefs::SlabEntryPacked,
 };
 use jiminy_cpi::{
+    account::Abr,
     pda::{PdaSeed, PdaSigner},
     program_error::{INVALID_ACCOUNT_DATA, INVALID_ARGUMENT, NOT_ENOUGH_ACCOUNT_KEYS},
 };
@@ -21,7 +22,7 @@ use sanctum_system_jiminy::{
 use crate::{
     pay_for_rent_exempt_shortfall,
     utils::{verify_pks, Cpi, SYS_PROG_ID},
-    Accounts, CustomProgErr,
+    CustomProgErr,
 };
 
 pub type InitIxAccHandles<'a> = InitIxAccs<AccountHandle<'a>>;
@@ -35,14 +36,15 @@ fn expected_init_ix_keys(payer: &[u8; 32]) -> InitIxKeys<'_> {
 }
 
 pub fn init_accs_checked<'acc>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
+    accounts: &[AccountHandle<'acc>],
 ) -> Result<InitIxAccHandles<'acc>, ProgramError> {
-    let Some(init_accs) = accounts.as_slice().first_chunk() else {
+    let Some(init_accs) = accounts.first_chunk() else {
         return Err(NOT_ENOUGH_ACCOUNT_KEYS.into());
     };
     let accs = InitIxAccHandles::new(*init_accs);
-    let payer_key = accounts.get(*accs.payer()).key();
-    verify_pks(accounts, &accs.0, &expected_init_ix_keys(payer_key).0).map_err(
+    let payer_key = abr.get(*accs.payer()).key();
+    verify_pks(abr, &accs.0, &expected_init_ix_keys(payer_key).0).map_err(
         |(_actual, expected)| match *expected {
             SLAB_ID => ProgramError::from(CustomProgErr(FlatSlabProgramErr::WrongSlabAcc)),
             _ => INVALID_ARGUMENT.into(),
@@ -59,19 +61,19 @@ pub fn init_accs_checked<'acc>(
 const INIT_ACC_LEN: usize = Slab::account_size(1);
 
 pub fn process_init<'acc>(
-    accounts: &mut Accounts<'acc>,
+    abr: &mut Abr,
     accs: InitIxAccHandles<'acc>,
     prog_id: &[u8; 32],
 ) -> Result<(), ProgramError> {
     let mut cpi = Cpi::new();
 
-    let slab = accounts.get(*accs.slab());
+    let slab = abr.get(*accs.slab());
     if *slab.owner() != SYS_PROG_ID {
         return Err(INVALID_ACCOUNT_DATA.into());
     }
 
     pay_for_rent_exempt_shortfall(
-        accounts,
+        abr,
         &mut cpi,
         NewTransferIxAccsBuilder::start()
             .with_from(*accs.payer())
@@ -81,7 +83,7 @@ pub fn process_init<'acc>(
     )?;
 
     assign_invoke_signed(
-        accounts,
+        abr,
         &mut cpi,
         NewAssignIxAccsBuilder::start()
             .with_assign(*accs.slab())
@@ -93,7 +95,7 @@ pub fn process_init<'acc>(
         ])],
     )?;
 
-    let slab = accounts.get_mut(*accs.slab());
+    let slab = abr.get_mut(*accs.slab());
     slab.realloc(INIT_ACC_LEN, false)?;
 
     let mut slabmut = SlabMut::of_acc_data(slab.data_mut()).ok_or(INVALID_ACCOUNT_DATA)?;

--- a/pricing/flatslab/program/src/instructions/pricing/common.rs
+++ b/pricing/flatslab/program/src/instructions/pricing/common.rs
@@ -6,50 +6,51 @@ use inf1_pp_flatslab_core::{
     pricing::FlatSlabSwapPricing,
     typedefs::SlabEntryPackedList,
 };
-use jiminy_cpi::program_error::NOT_ENOUGH_ACCOUNT_KEYS;
+use jiminy_cpi::{account::Abr, program_error::NOT_ENOUGH_ACCOUNT_KEYS};
 use jiminy_entrypoint::{account::AccountHandle, program_error::ProgramError};
 
-use crate::{err::CustomProgErr, utils::verify_pks, Accounts};
-
-pub type PricingIxSufAccHandles<'a> = IxSufAccs<AccountHandle<'a>>;
+use crate::{err::CustomProgErr, utils::verify_pks};
 
 const EXPECTED_PRICING_IX_SUF_ACC_KEYS: IxSufKeys = IxSufKeys::new([&SLAB_ID]);
 
+pub type PricingIxSufAccHandles<'a> = IxSufAccs<AccountHandle<'a>>;
+
 // Price
 
-pub type PriceIxPreAccHandles<'a> = inf1_pp_core::instructions::price::IxPreAccs<AccountHandle<'a>>;
+pub type PriceIxPreAccs<T> = inf1_pp_core::instructions::price::IxPreAccs<T>;
+
+pub type PriceIxAccHandles<'acc> =
+    inf1_pp_core::instructions::price::IxAccs<AccountHandle<'acc>, PricingIxSufAccHandles<'acc>>;
 
 pub fn pricing_accs_checked<'acc>(
-    accounts: &Accounts<'acc>,
-) -> Result<(PriceIxPreAccHandles<'acc>, PricingIxSufAccHandles<'acc>), ProgramError> {
-    use inf1_pp_core::instructions::price::IX_PRE_ACCS_LEN;
-
+    abr: &Abr,
+    accounts: &[AccountHandle<'acc>],
+) -> Result<PriceIxAccHandles<'acc>, ProgramError> {
     let Some((pre, suf)) = accounts
-        .as_slice()
-        .split_first_chunk::<IX_PRE_ACCS_LEN>()
+        .split_first_chunk()
         .and_then(|(pre, rest)| rest.first().map(|suf| (pre, suf)))
     else {
         return Err(NOT_ENOUGH_ACCOUNT_KEYS.into());
     };
 
-    let pre = PriceIxPreAccHandles::new(*pre);
+    let pre = PriceIxPreAccs::new(*pre);
     let suf = PricingIxSufAccHandles::new([*suf]);
 
     // check identities (only slab)
-    verify_pks(accounts, &suf.0, &EXPECTED_PRICING_IX_SUF_ACC_KEYS.0)
+    verify_pks(abr, &suf.0, &EXPECTED_PRICING_IX_SUF_ACC_KEYS.0)
         .map_err(|_| CustomProgErr(FlatSlabProgramErr::WrongSlabAcc))?;
 
     // no need to check signers here, all accounts are non-signers
 
-    Ok((pre, suf))
+    Ok(PriceIxAccHandles::new(pre, suf))
 }
 
 pub fn swap_pricing(
-    accounts: &Accounts,
+    abr: &Abr,
     entries: SlabEntryPackedList,
     pair: Pair<AccountHandle>,
 ) -> Result<FlatSlabSwapPricing, ProgramError> {
-    let mints = pair.map(|h| accounts.get(h).key());
+    let mints = pair.map(|h| abr.get(h).key());
     entries
         .pricing(&mints)
         .map_err(|e| CustomProgErr(FlatSlabProgramErr::MintNotFound(e)).into())
@@ -62,14 +63,18 @@ pub type LpIxPreAccHandles<'a> =
     inf1_pp_core::instructions::deprecated::lp::IxPreAccs<AccountHandle<'a>>;
 
 #[allow(deprecated)]
-pub fn lp_accs_checked<'acc>(
-    accounts: &Accounts<'acc>,
-) -> Result<(LpIxPreAccHandles<'acc>, PricingIxSufAccHandles<'acc>), ProgramError> {
-    use inf1_pp_core::instructions::deprecated::lp::IX_PRE_ACCS_LEN;
+pub type LpIxAccHandles<'acc> = inf1_pp_core::instructions::deprecated::lp::IxAccs<
+    AccountHandle<'acc>,
+    PricingIxSufAccHandles<'acc>,
+>;
 
+#[allow(deprecated)]
+pub fn lp_accs_checked<'acc>(
+    abr: &Abr,
+    accounts: &[AccountHandle<'acc>],
+) -> Result<LpIxAccHandles<'acc>, ProgramError> {
     let Some((pre, suf)) = accounts
-        .as_slice()
-        .split_first_chunk::<IX_PRE_ACCS_LEN>()
+        .split_first_chunk()
         .and_then(|(pre, rest)| rest.first().map(|suf| (pre, suf)))
     else {
         return Err(NOT_ENOUGH_ACCOUNT_KEYS.into());
@@ -79,10 +84,10 @@ pub fn lp_accs_checked<'acc>(
     let suf = PricingIxSufAccHandles::new([*suf]);
 
     // check identities (only slab)
-    verify_pks(accounts, &suf.0, &EXPECTED_PRICING_IX_SUF_ACC_KEYS.0)
+    verify_pks(abr, &suf.0, &EXPECTED_PRICING_IX_SUF_ACC_KEYS.0)
         .map_err(|_| CustomProgErr(FlatSlabProgramErr::WrongSlabAcc))?;
 
     // no need to check signers here, all accounts are non-signers
 
-    Ok((pre, suf))
+    Ok(LpIxAccHandles::new(pre, suf))
 }

--- a/pricing/flatslab/program/src/instructions/pricing/exact_in.rs
+++ b/pricing/flatslab/program/src/instructions/pricing/exact_in.rs
@@ -1,30 +1,26 @@
 use inf1_pp_core::{instructions::IxArgs, pair::Pair, traits::main::PriceExactIn};
 use inf1_pp_flatslab_core::{accounts::Slab, errs::FlatSlabProgramErr};
+use jiminy_cpi::account::Abr;
 use jiminy_entrypoint::program_error::{ProgramError, INVALID_ACCOUNT_DATA};
 use jiminy_return_data::set_return_data;
 
 use crate::{
     err::CustomProgErr,
-    instructions::pricing::{
-        common::{PriceIxPreAccHandles, PricingIxSufAccHandles},
-        swap_pricing,
-    },
-    Accounts,
+    instructions::pricing::{common::PriceIxAccHandles, swap_pricing},
 };
 
 pub fn process_price_exact_in(
-    accounts: &Accounts,
-    pre: &PriceIxPreAccHandles,
-    suf: &PricingIxSufAccHandles,
+    abr: &Abr,
+    PriceIxAccHandles { ix_prefix, suf }: &PriceIxAccHandles,
     args: IxArgs,
 ) -> Result<(), ProgramError> {
-    let slab = Slab::of_acc_data(accounts.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
+    let slab = Slab::of_acc_data(abr.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
     let ret = swap_pricing(
-        accounts,
+        abr,
         slab.entries(),
         Pair {
-            inp: *pre.input_mint(),
-            out: *pre.output_mint(),
+            inp: *ix_prefix.input_mint(),
+            out: *ix_prefix.output_mint(),
         },
     )?
     .price_exact_in(args)

--- a/pricing/flatslab/program/src/instructions/pricing/exact_out.rs
+++ b/pricing/flatslab/program/src/instructions/pricing/exact_out.rs
@@ -1,30 +1,26 @@
 use inf1_pp_core::{instructions::IxArgs, pair::Pair, traits::main::PriceExactOut};
 use inf1_pp_flatslab_core::{accounts::Slab, errs::FlatSlabProgramErr};
+use jiminy_cpi::account::Abr;
 use jiminy_entrypoint::program_error::{ProgramError, INVALID_ACCOUNT_DATA};
 use jiminy_return_data::set_return_data;
 
 use crate::{
     err::CustomProgErr,
-    instructions::pricing::{
-        common::{PriceIxPreAccHandles, PricingIxSufAccHandles},
-        swap_pricing,
-    },
-    Accounts,
+    instructions::pricing::{common::PriceIxAccHandles, swap_pricing},
 };
 
 pub fn process_price_exact_out(
-    accounts: &Accounts,
-    pre: &PriceIxPreAccHandles,
-    suf: &PricingIxSufAccHandles,
+    abr: &Abr,
+    PriceIxAccHandles { ix_prefix, suf }: &PriceIxAccHandles,
     args: IxArgs,
 ) -> Result<(), ProgramError> {
-    let slab = Slab::of_acc_data(accounts.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
+    let slab = Slab::of_acc_data(abr.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
     let ret = swap_pricing(
-        accounts,
+        abr,
         slab.entries(),
         Pair {
-            inp: *pre.input_mint(),
-            out: *pre.output_mint(),
+            inp: *ix_prefix.input_mint(),
+            out: *ix_prefix.output_mint(),
         },
     )?
     .price_exact_out(args)

--- a/pricing/flatslab/program/src/instructions/pricing/mint_lp.rs
+++ b/pricing/flatslab/program/src/instructions/pricing/mint_lp.rs
@@ -1,24 +1,20 @@
 use inf1_pp_core::{instructions::IxArgs, pair::Pair, traits::main::PriceExactIn};
 use inf1_pp_flatslab_core::{accounts::Slab, errs::FlatSlabProgramErr, keys::LP_MINT_ID};
+use jiminy_cpi::account::Abr;
 use jiminy_entrypoint::program_error::{ProgramError, INVALID_ACCOUNT_DATA};
 use jiminy_return_data::set_return_data;
 
-use crate::{
-    err::CustomProgErr,
-    instructions::pricing::common::{LpIxPreAccHandles, PricingIxSufAccHandles},
-    Accounts,
-};
+use crate::{err::CustomProgErr, instructions::pricing::common::LpIxAccHandles};
 
 #[allow(deprecated)]
 pub fn process_price_lp_tokens_to_mint(
-    accounts: &Accounts,
-    pre: &LpIxPreAccHandles,
-    suf: &PricingIxSufAccHandles,
+    abr: &Abr,
+    LpIxAccHandles { ix_prefix, suf }: &LpIxAccHandles,
     args: IxArgs,
 ) -> Result<(), ProgramError> {
-    let slab = Slab::of_acc_data(accounts.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
+    let slab = Slab::of_acc_data(abr.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
     let pair = Pair {
-        inp: accounts.get(*pre.mint()).key(),
+        inp: abr.get(*ix_prefix.mint()).key(),
         out: &LP_MINT_ID,
     };
     let ret = slab

--- a/pricing/flatslab/program/src/instructions/pricing/redeem_lp.rs
+++ b/pricing/flatslab/program/src/instructions/pricing/redeem_lp.rs
@@ -1,25 +1,21 @@
 use inf1_pp_core::{instructions::IxArgs, pair::Pair, traits::main::PriceExactIn};
 use inf1_pp_flatslab_core::{accounts::Slab, errs::FlatSlabProgramErr, keys::LP_MINT_ID};
+use jiminy_cpi::account::Abr;
 use jiminy_entrypoint::program_error::{ProgramError, INVALID_ACCOUNT_DATA};
 use jiminy_return_data::set_return_data;
 
-use crate::{
-    err::CustomProgErr,
-    instructions::pricing::common::{LpIxPreAccHandles, PricingIxSufAccHandles},
-    Accounts,
-};
+use crate::{err::CustomProgErr, instructions::pricing::common::LpIxAccHandles};
 
 #[allow(deprecated)]
 pub fn process_price_lp_tokens_to_redeem(
-    accounts: &Accounts,
-    pre: &LpIxPreAccHandles,
-    suf: &PricingIxSufAccHandles,
+    abr: &Abr,
+    LpIxAccHandles { ix_prefix, suf }: &LpIxAccHandles,
     args: IxArgs,
 ) -> Result<(), ProgramError> {
-    let slab = Slab::of_acc_data(accounts.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
+    let slab = Slab::of_acc_data(abr.get(*suf.slab()).data()).ok_or(INVALID_ACCOUNT_DATA)?;
     let pair = Pair {
         inp: &LP_MINT_ID,
-        out: accounts.get(*pre.mint()).key(),
+        out: abr.get(*ix_prefix.mint()).key(),
     };
     let ret = slab
         .entries()

--- a/pricing/flatslab/program/src/lib.rs
+++ b/pricing/flatslab/program/src/lib.rs
@@ -13,6 +13,7 @@ use inf1_pp_flatslab_core::{
         init::INIT_IX_DISCM,
     },
 };
+use jiminy_cpi::account::{Abr, AccountHandle};
 use jiminy_entrypoint::{
     program_entrypoint,
     program_error::{ProgramError, INVALID_INSTRUCTION_DATA},
@@ -46,61 +47,60 @@ pub use utils::*;
 /// Max possible accounts is 5 (SetLstFee)
 const MAX_ACCS: usize = 5;
 
-type Accounts<'account> = jiminy_entrypoint::account::Accounts<'account, MAX_ACCS>;
-
 program_entrypoint!(process_ix, MAX_ACCS);
 
 fn process_ix(
-    accounts: &mut Accounts,
+    abr: &mut Abr,
+    accounts: &[AccountHandle<'_>],
     data: &[u8],
     prog_id: &[u8; 32],
 ) -> Result<(), ProgramError> {
     match data.split_first().ok_or(INVALID_INSTRUCTION_DATA)? {
         // interface ixs
         (&PRICE_EXACT_IN_IX_DISCM, data) => {
-            let (pre, suf) = pricing_accs_checked(accounts)?;
+            let accs = pricing_accs_checked(abr, accounts)?;
             let args = IxArgs::parse(data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?);
-            process_price_exact_in(accounts, &pre, &suf, args)
+            process_price_exact_in(abr, &accs, args)
         }
         (&PRICE_EXACT_OUT_IX_DISCM, data) => {
-            let (pre, suf) = pricing_accs_checked(accounts)?;
+            let accs = pricing_accs_checked(abr, accounts)?;
             let args = IxArgs::parse(data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?);
-            process_price_exact_out(accounts, &pre, &suf, args)
+            process_price_exact_out(abr, &accs, args)
         }
         #[allow(deprecated)]
         (&PRICE_LP_TOKENS_TO_MINT_IX_DISCM, data) => {
-            let (pre, suf) = lp_accs_checked(accounts)?;
+            let accs = lp_accs_checked(abr, accounts)?;
             let args = IxArgs::parse(data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?);
-            process_price_lp_tokens_to_mint(accounts, &pre, &suf, args)
+            process_price_lp_tokens_to_mint(abr, &accs, args)
         }
         #[allow(deprecated)]
         (&PRICE_LP_TOKENS_TO_REDEEM_IX_DISCM, data) => {
-            let (pre, suf) = lp_accs_checked(accounts)?;
+            let accs = lp_accs_checked(abr, accounts)?;
             let args = IxArgs::parse(data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?);
-            process_price_lp_tokens_to_redeem(accounts, &pre, &suf, args)
+            process_price_lp_tokens_to_redeem(abr, &accs, args)
         }
 
         // init
         (&INIT_IX_DISCM, _data) => {
-            let accs = init_accs_checked(accounts)?;
-            process_init(accounts, accs, prog_id)
+            let accs = init_accs_checked(abr, accounts)?;
+            process_init(abr, accs, prog_id)
         }
 
         // admin ixs
         (&SET_ADMIN_IX_DISCM, _data) => {
-            let accs = set_admin_accs_checked(accounts)?;
-            process_set_admin(accounts, accs)
+            let accs = set_admin_accs_checked(abr, accounts)?;
+            process_set_admin(abr, accs)
         }
         (&SET_LST_FEE_IX_DISCM, data) => {
-            let accs = set_lst_fee_accs_checked(accounts)?;
+            let accs = set_lst_fee_accs_checked(abr, accounts)?;
             let args =
                 SetLstFeeIxArgs::parse(data.try_into().map_err(|_e| INVALID_INSTRUCTION_DATA)?)
                     .map_err(|e| CustomProgErr(FlatSlabProgramErr::FeeNanosOutOfRange(e)))?;
-            process_set_lst_fee(accounts, accs, args)
+            process_set_lst_fee(abr, accs, args)
         }
         (&REMOVE_LST_IX_DISCM, _data) => {
-            let accs = remove_lst_accs_checked(accounts)?;
-            process_remove_lst(accounts, accs)
+            let accs = remove_lst_accs_checked(abr, accounts)?;
+            process_remove_lst(abr, accs)
         }
 
         _ => Err(INVALID_INSTRUCTION_DATA.into()),

--- a/pricing/flatslab/program/src/utils.rs
+++ b/pricing/flatslab/program/src/utils.rs
@@ -1,10 +1,13 @@
 use inf1_pp_flatslab_core::{accounts::Slab, errs::FlatSlabProgramErr, keys::SLAB_ID};
-use jiminy_cpi::program_error::{ProgramError, INVALID_ARGUMENT};
+use jiminy_cpi::{
+    account::Abr,
+    program_error::{ProgramError, INVALID_ARGUMENT},
+};
 use jiminy_entrypoint::account::AccountHandle;
 use jiminy_sysvar_rent::{sysvar::SimpleSysvar, Rent};
 use sanctum_system_jiminy::instructions::transfer::{transfer_invoke_fwd, TransferIxAccounts};
 
-use crate::{Accounts, CustomProgErr};
+use crate::CustomProgErr;
 
 /// SystemInstruction::transfer
 const MAX_CPI_ACCS: usize = 2;
@@ -15,21 +18,21 @@ pub const SYS_PROG_ID: [u8; 32] = [0u8; 32];
 
 #[inline]
 pub fn verify_pks<'a, 'acc, const LEN: usize>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>; LEN],
     expected: &'a [&[u8; 32]; LEN], // we can use &[u8; 32] instead of [u8; 32] here bec we dont have any dynamic PDAs to verify
 ) -> Result<(), (&'a AccountHandle<'acc>, &'a [u8; 32])> {
-    verify_pks_slice(accounts, handles, expected)
+    verify_pks_slice(abr, handles, expected)
 }
 
 /// [`verify_pks`] delegates to this to minimize monomorphization  
 fn verify_pks_slice<'a, 'acc>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>],
     expected: &'a [&[u8; 32]],
 ) -> Result<(), (&'a AccountHandle<'acc>, &'a [u8; 32])> {
     handles.iter().zip(expected).try_for_each(|(h, e)| {
-        if accounts.get(*h).key() == *e {
+        if abr.get(*h).key() == *e {
             Ok(())
         } else {
             Err((h, *e))
@@ -49,16 +52,16 @@ pub fn admin_ix_verify_pks_err(expected: &[u8; 32], slab: Slab) -> ProgramError 
 
 #[inline]
 pub fn verify_signers<'a, 'acc, const LEN: usize>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>; LEN],
     expected_is_signer: &'a [bool; LEN],
 ) -> Result<(), &'a AccountHandle<'acc>> {
-    verify_signers_slice(accounts, handles, expected_is_signer)
+    verify_signers_slice(abr, handles, expected_is_signer)
 }
 
 /// [`verify_signers`] delegates to this to minimize monomorphization
 fn verify_signers_slice<'a, 'acc>(
-    accounts: &Accounts<'acc>,
+    abr: &Abr,
     handles: &'a [AccountHandle<'acc>],
     expected_is_signer: &'a [bool],
 ) -> Result<(), &'a AccountHandle<'acc>> {
@@ -66,7 +69,7 @@ fn verify_signers_slice<'a, 'acc>(
         .iter()
         .zip(expected_is_signer)
         .try_for_each(|(h, should_be_signer)| {
-            if *should_be_signer && !accounts.get(*h).is_signer() {
+            if *should_be_signer && !abr.get(*h).is_signer() {
                 Err(h)
             } else {
                 Ok(())
@@ -75,11 +78,11 @@ fn verify_signers_slice<'a, 'acc>(
 }
 
 pub fn admin_ix_verify_signers_err(
-    accounts: &Accounts,
+    abr: &Abr,
     expected_signer: AccountHandle,
     slab: Slab,
 ) -> ProgramError {
-    if accounts.get(expected_signer).key() == slab.admin() {
+    if abr.get(expected_signer).key() == slab.admin() {
         CustomProgErr(FlatSlabProgramErr::MissingAdminSignature).into()
     } else {
         INVALID_ARGUMENT.into()
@@ -87,17 +90,17 @@ pub fn admin_ix_verify_signers_err(
 }
 
 pub fn pay_for_rent_exempt_shortfall<'acc>(
-    accounts: &mut Accounts<'acc>,
+    abr: &mut Abr,
     cpi: &mut Cpi,
     handles: TransferIxAccounts<'acc>,
     data_len: usize,
 ) -> Result<(), ProgramError> {
     let lamports_shortfall = Rent::get()?
         .min_balance(data_len)
-        .saturating_sub(accounts.get(*handles.to()).lamports());
+        .saturating_sub(abr.get(*handles.to()).lamports());
 
     if lamports_shortfall > 0 {
-        transfer_invoke_fwd(accounts, cpi, handles, lamports_shortfall)?;
+        transfer_invoke_fwd(abr, cpi, handles, lamports_shortfall)?;
     }
 
     Ok(())

--- a/pricing/jiminy/src/cpi/price/lp.rs
+++ b/pricing/jiminy/src/cpi/price/lp.rs
@@ -1,16 +1,14 @@
-use core::ops::Range;
-
 use inf1_pp_core::instructions::{
     price::{
         exact_in::{PriceExactInIxArgs, PriceExactInIxData},
         exact_out::{PriceExactOutIxArgs, PriceExactOutIxData},
-        IxAccs, IxPreAccs,
+        IxAccs,
     },
     IX_DATA_LEN,
 };
 use jiminy_cpi::{
-    account::{AccountHandle, Accounts},
-    program_error::{ProgramError, BORSH_IO_ERROR, NOT_ENOUGH_ACCOUNT_KEYS},
+    account::{Abr, AccountHandle},
+    program_error::{ProgramError, BORSH_IO_ERROR},
     Cpi, CpiBuilder,
 };
 use jiminy_return_data::get_return_data;
@@ -30,75 +28,60 @@ pub type PriceExactOutIxAccountHandles<'a, P> = IxAccountHandles<'a, P>;
 
 /// Price exact in using CPI
 #[inline]
-pub fn cpi_price_exact_in<'cpi, 'accounts, const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
+pub fn cpi_price_exact_in<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
-    accounts: &'cpi mut Accounts<'accounts, MAX_ACCS>,
+    abr: &'cpi mut Abr,
     pricing_prog: AccountHandle<'accounts>,
     ix_args: PriceExactInIxArgs,
-    ix_prefix: IxPreAccs<AccountHandle<'accounts>>,
-    suf_range: Range<usize>,
+    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
 ) -> Result<u64, ProgramError> {
     prepare(
         cpi,
-        accounts,
+        abr,
         pricing_prog,
         PriceExactInIxData::new(ix_args).as_buf(),
-        ix_prefix,
-        suf_range,
+        accs,
     )
     .and_then(invoke)
 }
 
 /// Price exact out using CPI
 #[inline]
-pub fn price_exact_out<'cpi, 'accounts, const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
+pub fn price_exact_out<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
-    accounts: &'cpi mut Accounts<'accounts, MAX_ACCS>,
+    abr: &'cpi mut Abr,
     pricing_prog: AccountHandle<'accounts>,
     ix_data: PriceExactOutIxArgs,
-    ix_prefix: IxPreAccs<AccountHandle<'accounts>>,
-    suf_range: Range<usize>,
+    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
 ) -> Result<u64, ProgramError> {
     prepare(
         cpi,
-        accounts,
+        abr,
         pricing_prog,
         PriceExactOutIxData::new(ix_data).as_buf(),
-        ix_prefix,
-        suf_range,
+        accs,
     )
     .and_then(invoke)
 }
 
 #[inline]
-fn prepare<'cpi, 'accounts, const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
+fn prepare<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
-    accounts: &'cpi mut Accounts<'accounts, MAX_ACCS>,
+    abr: &'cpi mut Abr,
     pricing_prog: AccountHandle<'accounts>,
     ix_data: &'cpi [u8; IX_DATA_LEN],
-    ix_prefix: IxPreAccs<AccountHandle<'accounts>>,
-    suf_range: Range<usize>,
-) -> Result<CpiBuilder<'cpi, 'accounts, MAX_CPI_ACCS, MAX_ACCS, true>, ProgramError> {
-    let mut res = CpiBuilder::new(cpi, accounts)
+    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+) -> Result<CpiBuilder<'cpi, MAX_CPI_ACCS, true>, ProgramError> {
+    CpiBuilder::new(cpi, abr)
         .with_prog_handle(pricing_prog)
-        .with_ix_data(ix_data);
-    res.try_derive_accounts_fwd(|accounts| {
-        let suf = accounts
-            .as_slice()
-            .get(suf_range)
-            .ok_or(NOT_ENOUGH_ACCOUNT_KEYS)?;
-        // very unfortunate we cant use
-        // IxAccs<AccountHandle<'a>, S>
-        // because cannot return reference to temporary in closure
-        Ok(ix_prefix.0.into_iter().chain(suf.iter().copied()))
-    })?;
-    Ok(res)
+        .with_ix_data(ix_data)
+        .with_accounts_fwd(accs.seq().copied())
 }
 
 // Invoke interface shared by all ixs in this lib
 #[inline]
-fn invoke<const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
-    cpi: CpiBuilder<'_, '_, MAX_CPI_ACCS, MAX_ACCS, true>,
+fn invoke<const MAX_CPI_ACCS: usize>(
+    cpi: CpiBuilder<'_, MAX_CPI_ACCS, true>,
 ) -> Result<u64, ProgramError> {
     cpi.invoke()?;
     let data_opt = get_return_data::<8>();

--- a/sol-val-calc/jiminy/src/cpi.rs
+++ b/sol-val-calc/jiminy/src/cpi.rs
@@ -1,51 +1,49 @@
-use core::ops::{Range, RangeInclusive};
+use core::ops::RangeInclusive;
 
 use inf1_svc_core::instructions::{
-    lst_to_sol::LstToSolIxData, sol_to_lst::SolToLstIxData, IxPreAccs, IX_DATA_LEN,
+    lst_to_sol::LstToSolIxData, sol_to_lst::SolToLstIxData, IxAccs, IX_DATA_LEN,
 };
 use jiminy_cpi::{
-    account::{AccountHandle, Accounts},
-    program_error::{ProgramError, BORSH_IO_ERROR, NOT_ENOUGH_ACCOUNT_KEYS},
+    account::{Abr, AccountHandle},
+    program_error::{ProgramError, BORSH_IO_ERROR},
     Cpi, CpiBuilder,
 };
 use jiminy_return_data::get_return_data;
 
+pub type IxAccountHandles<'a, P> = IxAccs<AccountHandle<'a>, P>;
+
 #[inline]
-pub fn cpi_sol_to_lst<'cpi, 'accounts, const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
+pub fn cpi_sol_to_lst<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
-    accounts: &'cpi mut Accounts<'accounts, MAX_ACCS>,
+    abr: &'cpi mut Abr,
     svc_prog: AccountHandle<'accounts>,
     lamports: u64,
-    ix_prefix: IxPreAccs<AccountHandle<'accounts>>,
-    suf_range: Range<usize>,
+    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
 ) -> Result<RangeInclusive<u64>, ProgramError> {
     prepare(
         cpi,
-        accounts,
+        abr,
         svc_prog,
         SolToLstIxData::new(lamports).as_buf(),
-        ix_prefix,
-        suf_range,
+        accs,
     )
     .and_then(invoke)
 }
 
 #[inline]
-pub fn cpi_lst_to_sol<'cpi, 'accounts, const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
+pub fn cpi_lst_to_sol<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
-    accounts: &'cpi mut Accounts<'accounts, MAX_ACCS>,
+    abr: &'cpi mut Abr,
     svc_prog: AccountHandle<'accounts>,
     lst_amt: u64,
-    ix_prefix: IxPreAccs<AccountHandle<'accounts>>,
-    suf_range: Range<usize>,
+    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
 ) -> Result<RangeInclusive<u64>, ProgramError> {
     prepare(
         cpi,
-        accounts,
+        abr,
         svc_prog,
         LstToSolIxData::new(lst_amt).as_buf(),
-        ix_prefix,
-        suf_range,
+        accs,
     )
     .and_then(invoke)
 }
@@ -54,33 +52,22 @@ pub fn cpi_lst_to_sol<'cpi, 'accounts, const MAX_CPI_ACCS: usize, const MAX_ACCS
 // in case we need to expose them to public in the future
 
 #[inline]
-fn prepare<'cpi, 'accounts, const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
+fn prepare<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
-    accounts: &'cpi mut Accounts<'accounts, MAX_ACCS>,
+    abr: &'cpi mut Abr,
     svc_prog: AccountHandle<'accounts>,
     ix_data: &'cpi [u8; IX_DATA_LEN],
-    ix_prefix: IxPreAccs<AccountHandle<'accounts>>,
-    suf_range: Range<usize>,
-) -> Result<CpiBuilder<'cpi, 'accounts, MAX_CPI_ACCS, MAX_ACCS, true>, ProgramError> {
-    let mut res = CpiBuilder::new(cpi, accounts)
+    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+) -> Result<CpiBuilder<'cpi, MAX_CPI_ACCS, true>, ProgramError> {
+    CpiBuilder::new(cpi, abr)
         .with_prog_handle(svc_prog)
-        .with_ix_data(ix_data);
-    res.try_derive_accounts_fwd(|accounts| {
-        let suf = accounts
-            .as_slice()
-            .get(suf_range)
-            .ok_or(NOT_ENOUGH_ACCOUNT_KEYS)?;
-        // very unfortunate we cant use
-        // IxAccs<AccountHandle<'a>, S>
-        // because cannot return reference to temporary in closure
-        Ok(ix_prefix.0.into_iter().chain(suf.iter().copied()))
-    })?;
-    Ok(res)
+        .with_ix_data(ix_data)
+        .with_accounts_fwd(accs.seq().copied())
 }
 
 #[inline]
-fn invoke<const MAX_CPI_ACCS: usize, const MAX_ACCS: usize>(
-    cpi: CpiBuilder<'_, '_, MAX_CPI_ACCS, MAX_ACCS, true>,
+fn invoke<const MAX_CPI_ACCS: usize>(
+    cpi: CpiBuilder<'_, MAX_CPI_ACCS, true>,
 ) -> Result<RangeInclusive<u64>, ProgramError> {
     cpi.invoke()?;
     let data_opt = get_return_data::<16>();


### PR DESCRIPTION
Pull in changes in [split accounts & Abr](https://github.com/igneous-labs/jiminy/pull/38). Instructions with variable length account-suffixes can now just use `&[AccountHandle]` directly instead of `Range<usize>`