### PR TITLE
Undo sol-val-calc spinoff

### DIFF
--- a/controller/program/src/instructions/swap/v2/exact_in.rs
+++ b/controller/program/src/instructions/swap/v2/exact_in.rs
@@ -119,7 +119,7 @@ fn exec_calc_cpis_unchecked(
             abr,
             inp_calc_prog,
             amount,
-            SvcIxAccountHandles {
+            &SvcIxAccountHandles {
                 ix_prefix: NewSvcIxPreAccsBuilder::start()
                     .with_lst_mint(*ix_prefix.inp_mint())
                     .build(),
@@ -162,7 +162,7 @@ fn exec_calc_cpis_unchecked(
             abr,
             out_calc_prog,
             out_sol_val,
-            SvcIxAccountHandles {
+            &SvcIxAccountHandles {
                 ix_prefix: NewSvcIxPreAccsBuilder::start()
                     .with_lst_mint(*ix_prefix.out_mint())
                     .build(),

--- a/controller/program/src/instructions/swap/v2/exact_out.rs
+++ b/controller/program/src/instructions/swap/v2/exact_out.rs
@@ -120,7 +120,7 @@ fn exec_calc_cpis_unchecked(
             abr,
             out_calc_prog,
             amount,
-            SvcIxAccountHandles {
+            &SvcIxAccountHandles {
                 ix_prefix: NewSvcIxPreAccsBuilder::start()
                     .with_lst_mint(*ix_prefix.out_mint())
                     .build(),
@@ -163,7 +163,7 @@ fn exec_calc_cpis_unchecked(
             abr,
             inp_calc_prog,
             inp_sol_val,
-            SvcIxAccountHandles {
+            &SvcIxAccountHandles {
                 ix_prefix: NewSvcIxPreAccsBuilder::start()
                     .with_lst_mint(*ix_prefix.inp_mint())
                     .build(),

--- a/controller/program/src/svc.rs
+++ b/controller/program/src/svc.rs
@@ -69,7 +69,7 @@ pub fn cpi_lst_reserves_sol_val(
         abr,
         calc_prog,
         lst_balance,
-        SvcIxAccountHandles::new(
+        &SvcIxAccountHandles::new(
             NewSvcIxPreAccsBuilder::start()
                 .with_lst_mint(*ix_prefix.lst_mint())
                 .build(),

--- a/sol-val-calc/README.md
+++ b/sol-val-calc/README.md
@@ -3,3 +3,9 @@
 INF SOL value calculator programs.
 
 See https://github.com/igneous-labs/S/tree/master/docs/sol-value-calculator-programs
+
+## Dependency + Organization
+
+Given their general utility as a redemption rate oracle for LSTs, the SOL value calculator programs are used by various other projects and programs in the ecosystem.
+
+Despite this load-bearing nature, they continue to be developed in this repo instead of being [spun-off](https://github.com/igneous-labs/sol-val-calc) to avoid circular dependency issues with the INF SOL value calculator program.

--- a/sol-val-calc/jiminy/src/cpi.rs
+++ b/sol-val-calc/jiminy/src/cpi.rs
@@ -18,9 +18,28 @@ pub fn cpi_sol_to_lst<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     abr: &'cpi mut Abr,
     svc_prog: &'cpi [u8; 32],
     lamports: u64,
-    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+    accs: &IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
 ) -> Result<RangeInclusive<u64>, ProgramError> {
     prepare(
+        cpi,
+        abr,
+        svc_prog,
+        SolToLstIxData::new(lamports).as_buf(),
+        accs,
+    )
+    .and_then(invoke)
+}
+
+/// [`cpi_sol_to_lst`] but using a svc program address instead of handle
+#[inline]
+pub fn cpi_sol_to_lst_id<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
+    cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
+    abr: &'cpi mut Abr,
+    svc_prog: &'cpi [u8; 32],
+    lamports: u64,
+    accs: &IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+) -> Result<RangeInclusive<u64>, ProgramError> {
+    prepare_id(
         cpi,
         abr,
         svc_prog,
@@ -36,9 +55,28 @@ pub fn cpi_lst_to_sol<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     abr: &'cpi mut Abr,
     svc_prog: &'cpi [u8; 32],
     lst_amt: u64,
-    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+    accs: &IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
 ) -> Result<RangeInclusive<u64>, ProgramError> {
     prepare(
+        cpi,
+        abr,
+        svc_prog,
+        LstToSolIxData::new(lst_amt).as_buf(),
+        accs,
+    )
+    .and_then(invoke)
+}
+
+/// [`cpi_lst_to_sol`] but using a svc program address instead of handle
+#[inline]
+pub fn cpi_lst_to_sol_id<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
+    cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
+    abr: &'cpi mut Abr,
+    svc_prog: &'cpi [u8; 32],
+    lst_amt: u64,
+    accs: &IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+) -> Result<RangeInclusive<u64>, ProgramError> {
+    prepare_id(
         cpi,
         abr,
         svc_prog,
@@ -57,7 +95,22 @@ fn prepare<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
     abr: &'cpi mut Abr,
     svc_prog: &'cpi [u8; 32],
     ix_data: &'cpi [u8; IX_DATA_LEN],
-    accs: IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+    accs: &IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
+) -> Result<CpiBuilder<'cpi, MAX_CPI_ACCS, true>, ProgramError> {
+    CpiBuilder::new(cpi, abr)
+        .with_prog_id(svc_prog)
+        .with_ix_data(ix_data)
+        .with_accounts_fwd(accs.seq().copied())
+}
+
+/// [`prepare`] but using a svc program address instead of handle
+#[inline]
+fn prepare_id<'cpi, 'accounts, const MAX_CPI_ACCS: usize>(
+    cpi: &'cpi mut Cpi<MAX_CPI_ACCS>,
+    abr: &'cpi mut Abr,
+    svc_prog: &'cpi [u8; 32],
+    ix_data: &'cpi [u8; IX_DATA_LEN],
+    accs: &IxAccountHandles<'accounts, impl AsRef<[AccountHandle<'accounts>]>>,
 ) -> Result<CpiBuilder<'cpi, MAX_CPI_ACCS, true>, ProgramError> {
     CpiBuilder::new(cpi, abr)
         .with_prog_id(svc_prog)

--- a/sol-val-calc/marinade/std/src/lib.rs
+++ b/sol-val-calc/marinade/std/src/lib.rs
@@ -9,7 +9,7 @@ pub mod update;
 pub struct MarinadeSvcStd {
     /// Might be `None` at initialization before accounts required
     /// to create the calc have been fetched
-    calc: Option<MarinadeCalc>,
+    pub calc: Option<MarinadeCalc>,
 }
 
 impl Default for MarinadeSvcStd {

--- a/sol-val-calc/spl/std/src/lib.rs
+++ b/sol-val-calc/spl/std/src/lib.rs
@@ -16,8 +16,8 @@ pub type SplSvcStd = GenSplSvcStd<SplCalcAccs>;
 pub struct GenSplSvcStd<A> {
     /// Might be `None` at initialization before accounts required
     /// to create the calc have been fetched
-    calc: Option<SplCalc>,
-    accs: A,
+    pub calc: Option<SplCalc>,
+    pub accs: A,
 }
 
 /// Constructors

--- a/ts/sdk/src/interface.rs
+++ b/ts/sdk/src/interface.rs
@@ -29,6 +29,11 @@ impl inf1_std::update::Account for Account {
     fn data(&self) -> &[u8] {
         &self.data
     }
+
+    #[inline]
+    fn lamports(&self) -> u64 {
+        self.lamports
+    }
 }
 
 impl UpdateMap for AccountMap {
@@ -56,6 +61,7 @@ pub struct SplPoolAccounts(pub HashMap<B58PK, B58PK>);
 pub struct Account {
     pub data: ByteBuf,
     pub owner: B58PK,
+    pub lamports: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Tsify)]

--- a/ts/tests/utils/rpc.ts
+++ b/ts/tests/utils/rpc.ts
@@ -37,6 +37,7 @@ export async function fetchAccountMap(
           {
             data: new Uint8Array(getBase64Encoder().encode(v.data[0])),
             owner: v.owner,
+            lamports: v.lamports,
           },
         ];
       }),

--- a/update-traits/src/lib.rs
+++ b/update-traits/src/lib.rs
@@ -4,6 +4,8 @@ use core::{error::Error, fmt::Display};
 
 pub trait Account {
     fn data(&self) -> &[u8];
+
+    fn lamports(&self) -> u64;
 }
 
 // cant generalize over for Deref<T> due to lifetime of &[u8]
@@ -12,6 +14,11 @@ impl<T: Account> Account for &T {
     #[inline]
     fn data(&self) -> &[u8] {
         (*self).data()
+    }
+
+    #[inline]
+    fn lamports(&self) -> u64 {
+        (*self).lamports()
     }
 }
 


### PR DESCRIPTION
Merge changes in https://github.com/igneous-labs/sol-val-calc back in so that we can retire that repo for reasons documented in the changes here.